### PR TITLE
[DO NOT MERGE] Implementation of default IKM that returns all zeroes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ cmd/core-data/core-data
 cmd/core-metadata/core-metadata
 cmd/export-client/export-client
 cmd/export-distro/export-distro
+cmd/security-default-ikm/security-default-ikm
 cmd/security-secrets-setup/security-secrets-setup
 cmd/security-proxy-setup/security-proxy-setup
 cmd/support-logging/support-logging

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOCGO=CGO_ENABLED=1 GO111MODULE=on go
 DOCKERS=docker_config_seed docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent docker_support_scheduler docker_security_secrets_setup docker_security_proxy_setup
 .PHONY: $(DOCKERS)
 
-MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup
+MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-default-ikm/security-default-ikm cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup
 
 .PHONY: $(MICROSERVICES)
 
@@ -60,6 +60,9 @@ cmd/sys-mgmt-agent/sys-mgmt-agent:
 
 cmd/support-scheduler/support-scheduler:
 	$(GO) build $(GOFLAGS) -o $@ ./cmd/support-scheduler
+
+cmd/security-default-ikm/security-default-ikm:
+	$(GO) build $(GOFLAGS) -o ./cmd/security-default-ikm/security-default-ikm ./cmd/security-default-ikm
 
 cmd/security-secrets-setup/security-secrets-setup:
 	$(GO) build $(GOFLAGS) -o ./cmd/security-secrets-setup/security-secrets-setup ./cmd/security-secrets-setup

--- a/cmd/security-default-ikm/main.go
+++ b/cmd/security-default-ikm/main.go
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package main
+
+import (
+	"encoding/hex"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/default-ikm/ikm"
+)
+
+var exitInstance = newExit()
+var defaultIkm = ikm.NewDefaultIkm()
+
+func main() {
+
+	ikm := defaultIkm.Ikm()
+	ikmOctets := hex.EncodeToString(ikm)
+	os.Stdout.WriteString(ikmOctets)
+	os.Stdout.Close()
+
+	exitInstance.callExit(0)
+}
+
+type ikmProducer interface {
+	Ikm() []byte
+}
+
+type exit interface {
+	callExit(int)
+}
+
+type exitCode struct{}
+
+func newExit() exit {
+	return &exitCode{}
+}
+
+func (*exitCode) callExit(statusCode int) {
+	os.Exit(statusCode)
+}

--- a/cmd/security-default-ikm/main_test.go
+++ b/cmd/security-default-ikm/main_test.go
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoOption(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	runWithNoOption()
+
+	os.Stdout = oldStdout
+	w.Close()
+	var capture bytes.Buffer
+	io.Copy(&capture, r)
+	assert.Equal("0000000000000000000000000000000000000000000000000000000000000000", capture.String())
+	assert.Equal(0, (exitInstance.(*testExitCode)).getStatusCode())
+}
+
+func setupTest(t *testing.T) func(t *testing.T, args []string) {
+	exitInstance = newTestExit()
+	return func(t *testing.T, args []string) {
+		// reset after each test
+		os.Args = args
+	}
+}
+
+func runWithNoOption() {
+	// case 1: no option given
+	os.Args = []string{"cmd"}
+	main()
+}
+
+type testExitCode struct {
+	testStatusCode int
+}
+
+func newTestExit() exit {
+	return &testExitCode{}
+}
+
+func (testExit *testExitCode) callExit(statusCode int) {
+	fmt.Printf("In test: exitCode = %d\n", statusCode)
+	testExit.testStatusCode = statusCode
+}
+
+func (testExit *testExitCode) getStatusCode() int {
+	return testExit.testStatusCode
+}

--- a/internal/security/default-ikm/ikm/defaultikm.go
+++ b/internal/security/default-ikm/ikm/defaultikm.go
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package ikm
+
+// DefaultIkm provides a trivial IKM
+type DefaultIkm struct{}
+
+// NewIkm creates a new IKM producer
+func NewDefaultIkm() *DefaultIkm {
+	return &DefaultIkm{}
+}
+
+// Ikm returns some initial keying material.
+// The default IKM is 32-bytes of zero.
+func (*DefaultIkm) Ikm() []byte {
+	return make([]byte, 32)
+}

--- a/internal/security/default-ikm/ikm/defaultikm_test.go
+++ b/internal/security/default-ikm/ikm/defaultikm_test.go
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package ikm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTrivialIkm tests the default implementation
+func TestTrivialIkm(t *testing.T) {
+	ikmProducer := NewDefaultIkm()
+
+	ikm := ikmProducer.Ikm()
+
+	expected := make([]byte, 32)
+
+	assert.ElementsMatch(t, expected, ikm)
+}

--- a/internal/security/default-ikm/ikm/interface.go
+++ b/internal/security/default-ikm/ikm/interface.go
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package ikm
+
+// IkmProducer is the interface that the main program expects
+// for returning input key material
+type IkmProducer interface {
+	Ikm() []byte
+}


### PR DESCRIPTION
The default implementation of input key material supplier for
a key derivation function.  This is intended to be replaced
in production usage with a equivalent executable that returns
a device-specific secret encoded as hex bytes to stdout.
The IKM can be of any length, but recommend >= 32 octets worth.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>