### PR TITLE
[DO NOT MERGE] Implementation of default software-based key derivation function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ cmd/core-data/core-data
 cmd/core-metadata/core-metadata
 cmd/export-client/export-client
 cmd/export-distro/export-distro
+cmd/security-default-kdf/security-default-kdf
 cmd/security-secrets-setup/security-secrets-setup
 cmd/security-proxy-setup/security-proxy-setup
 cmd/support-logging/support-logging

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOCGO=CGO_ENABLED=1 GO111MODULE=on go
 DOCKERS=docker_config_seed docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent docker_support_scheduler docker_security_secrets_setup docker_security_proxy_setup
 .PHONY: $(DOCKERS)
 
-MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup
+MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-default-kdf/security-default-kdf cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup
 
 .PHONY: $(MICROSERVICES)
 
@@ -60,6 +60,9 @@ cmd/sys-mgmt-agent/sys-mgmt-agent:
 
 cmd/support-scheduler/support-scheduler:
 	$(GO) build $(GOFLAGS) -o $@ ./cmd/support-scheduler
+
+cmd/security-default-kdf/security-default-kdf:
+	$(GO) build $(GOFLAGS) -o ./cmd/security-default-kdf/security-default-kdf ./cmd/security-default-kdf
 
 cmd/security-secrets-setup/security-secrets-setup:
 	$(GO) build $(GOFLAGS) -o ./cmd/security-secrets-setup/security-secrets-setup ./cmd/security-secrets-setup

--- a/cmd/security-default-kdf/main.go
+++ b/cmd/security-default-kdf/main.go
@@ -1,0 +1,121 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/default-kdf/kdf"
+	"github.com/edgexfoundry/edgex-go/internal/security/pipedhexreader"
+)
+
+const defaultKeylen uint = 32
+const defaultIkmHook string = "security-default-ikm"
+
+var exitInstance = newExit()
+var hashConstructor = sha256.New
+var helpOpt bool
+var persistencePath string
+var hashAlg string
+var keylen uint
+var info string
+
+func init() {
+	// define and register command line flags:
+	flag.BoolVar(&helpOpt, "h", false, "help message")
+	flag.BoolVar(&helpOpt, "help", false, "help message")
+	flag.StringVar(&persistencePath, "pstoredir", "", "Path for storing data to be preserved across reboots")
+	flag.StringVar(&hashAlg, "halg", "sha256", "Hash algorithm to be used in key derivation function (\"sha256\")")
+	flag.UintVar(&keylen, "l", defaultKeylen, "Length of output key in octets")
+}
+
+func submain(ikmHandler pipedhexreader.PipedHexReader,
+	kdf kdf.KeyDeriver,
+	ikmHook string,
+	keylen uint,
+	stdout io.StringWriter,
+	info string) (int, error) {
+
+	ikm, err := ikmHandler.ReadHexBytesFromExe(ikmHook, []string{})
+	if err != nil {
+		return 1, err
+	}
+	key, err := kdf.DeriveKey(ikm, keylen, info)
+	if err != nil {
+		return 1, err
+	}
+	keyOctets := hex.EncodeToString(key)
+	stdout.WriteString(keyOctets)
+	return 0, nil
+}
+
+func main() {
+	flag.Parse()
+	info = flag.Arg(0)
+
+	var ikmHook = os.Getenv("IKM_HOOK")
+	if ikmHook == "" {
+		ikmHook = defaultIkmHook
+	}
+	if helpOpt {
+		flag.Usage()
+		exitInstance.callExit(0)
+		return
+	}
+	if persistencePath == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: -pstoredir is a required option")
+		exitInstance.callExit(1)
+		return
+	}
+	if hashAlg != "sha256" {
+		fmt.Fprintln(os.Stderr, "ERROR: -halg must be \"sha256\"")
+		exitInstance.callExit(1)
+		return
+	}
+	if info == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: An \"info\" argument is required as input to the KDF")
+		exitInstance.callExit(1)
+		return
+	}
+
+	pipedHexReader := pipedhexreader.NewPipedHexReader()
+	defaultKdf := kdf.NewDefaultKdf(persistencePath, hashConstructor)
+	exitcode, err := submain(pipedHexReader, defaultKdf, ikmHook, keylen, os.Stdout, info)
+	os.Stdout.Close()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	exitInstance.callExit(exitcode)
+}
+
+type exit interface {
+	callExit(int)
+}
+
+type exitCode struct{}
+
+func newExit() exit {
+	return &exitCode{}
+}
+
+func (*exitCode) callExit(statusCode int) {
+	os.Exit(statusCode)
+}

--- a/cmd/security-default-kdf/main_test.go
+++ b/cmd/security-default-kdf/main_test.go
@@ -46,7 +46,7 @@ func (testExit *testExitCode) getStatusCode() int {
 	return testExit.testStatusCode
 }
 
-// WcaptureWrapper wraps a lambda function to preseve os.Args and capture (and return stdin and stdout)
+// WcaptureWrapper wraps a lambda function to preserve os.Args and capture (and return) stdin and stdout
 func captureWrapper(t *testing.T, delegate func(t *testing.T) error) (bytes.Buffer, bytes.Buffer, error) {
 	var oldArgs []string
 	var oldStdout, oldStderr *os.File
@@ -96,7 +96,7 @@ func TestNoOption(t *testing.T) {
 	assert.Equal("ERROR: -persistdir is a required option\n", stderrCapture.String())
 }
 
-func TestBadHalg(t *testing.T) {
+func TestBadHashAlg(t *testing.T) {
 	assert := assert.New(t)
 
 	_, stderrCapture, err := captureWrapper(t, func(t *testing.T) error {
@@ -125,7 +125,7 @@ func TestNoInfo(t *testing.T) {
 }
 
 // TestNoError runs a mocked IKM and mocked KDF and
-// just makes sure submain() calls the right stuff
+// just makes sure outputDerviedKey() calls the right stuff
 func TestNoError(t *testing.T) {
 	assert := assert.New(t)
 

--- a/cmd/security-default-kdf/main_test.go
+++ b/cmd/security-default-kdf/main_test.go
@@ -1,0 +1,211 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/default-kdf/kdf"
+	"github.com/edgexfoundry/edgex-go/internal/security/pipedhexreader"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupTest(t *testing.T) func(t *testing.T, args []string) {
+	exitInstance = newTestExit()
+	return func(t *testing.T, args []string) {
+		// reset after each test
+		os.Args = args
+	}
+}
+
+type testExitCode struct {
+	testStatusCode int
+}
+
+func newTestExit() exit {
+	return &testExitCode{}
+}
+
+func (testExit *testExitCode) callExit(statusCode int) {
+	testExit.testStatusCode = statusCode
+}
+
+func (testExit *testExitCode) getStatusCode() int {
+	return testExit.testStatusCode
+}
+
+func TestNoOption(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	r2, w2, _ := os.Pipe()
+	os.Stdout = w
+	os.Stderr = w2
+
+	os.Args = []string{"cmd"}
+	main()
+
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	w.Close()
+	w2.Close()
+
+	assert.Equal(1, (exitInstance.(*testExitCode)).getStatusCode())
+
+	var stdoutCapture, stderrCapture bytes.Buffer
+	io.Copy(&stdoutCapture, r)
+	io.Copy(&stderrCapture, r2)
+	assert.Equal("ERROR: -pstoredir is a required option\n", stderrCapture.String())
+}
+
+func TestBadHalg(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	r2, w2, _ := os.Pipe()
+	os.Stdout = w
+	os.Stderr = w2
+
+	os.Args = []string{"cmd", "-pstoredir", ".", "-halg", "sha1"}
+	main()
+
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	w.Close()
+	w2.Close()
+
+	assert.Equal(1, (exitInstance.(*testExitCode)).getStatusCode())
+
+	var stdoutCapture, stderrCapture bytes.Buffer
+	io.Copy(&stdoutCapture, r)
+	io.Copy(&stderrCapture, r2)
+	assert.Equal("ERROR: -halg must be \"sha256\"\n", stderrCapture.String())
+}
+
+func TestNoInfo(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	r2, w2, _ := os.Pipe()
+	os.Stdout = w
+	os.Stderr = w2
+
+	os.Args = []string{"cmd", "-pstoredir", ".", "-halg", "sha256"}
+	main()
+
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	w.Close()
+	w2.Close()
+
+	assert.Equal(1, (exitInstance.(*testExitCode)).getStatusCode())
+
+	var stdoutCapture, stderrCapture bytes.Buffer
+	io.Copy(&stdoutCapture, r)
+	io.Copy(&stderrCapture, r2)
+	assert.Equal("ERROR: An \"info\" argument is required as input to the KDF\n", stderrCapture.String())
+}
+
+// TestNoError runs a mocked IKM and mocked KDF and
+// just makes sure submain() calls the right stuff
+func TestNoError(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	r, w, _ := os.Pipe()
+
+	exitCode, err := submain(newMockPipedHexReader(t), newMockKeyDeriver(t), "", 32, w, "info")
+
+	w.Close()
+
+	assert.Nil(err)
+	assert.Equal(0, exitCode)
+
+	var stdoutCapture bytes.Buffer
+	io.Copy(&stdoutCapture, r)
+	assert.Equal("1060e4e72054653bf46623844033f5ccc9cff596a4a680e074ef4fd06aae60df", stdoutCapture.String())
+}
+
+//
+// testing mocks - eliminate dependency on IKM_HOOK
+//
+
+type mockStringWriter struct {
+	t *testing.T
+}
+
+func newMockStringWriter(t *testing.T) io.StringWriter {
+	return &mockStringWriter{t}
+}
+
+func (wc *mockStringWriter) WriteString(s string) (n int, err error) {
+	assert.Equal(wc.t, "1060e4e72054653bf46623844033f5ccc9cff596a4a680e074ef4fd06aae60df", s)
+	return len(s), nil
+}
+
+func (wc *mockStringWriter) Close() error {
+	return nil
+}
+
+type mockPipedHexReader struct {
+	t *testing.T
+}
+
+func newMockPipedHexReader(t *testing.T) pipedhexreader.PipedHexReader {
+	return &mockPipedHexReader{t}
+}
+
+// ReadHexBytesFromExe see interface.go
+func (phr *mockPipedHexReader) ReadHexBytesFromExe(executable string, args []string) ([]byte, error) {
+	return make([]byte, 32), nil
+}
+
+type mockKeyDeriver struct {
+	t *testing.T
+}
+
+func newMockKeyDeriver(t *testing.T) kdf.KeyDeriver {
+	return &mockKeyDeriver{t}
+}
+
+func (kdf *mockKeyDeriver) DeriveKey(ikm []byte, keylen uint, info string) ([]byte, error) {
+	assert.Equal(kdf.t, uint(32), keylen)
+	assert.Equal(kdf.t, make([]byte, 32), ikm)
+	assert.Equal(kdf.t, "info", info)
+	bytes, _ := hex.DecodeString("1060e4e72054653bf46623844033f5ccc9cff596a4a680e074ef4fd06aae60df")
+	return bytes, nil
+}

--- a/internal/security/default-kdf/kdf/defaultkdf.go
+++ b/internal/security/default-kdf/kdf/defaultkdf.go
@@ -28,8 +28,8 @@ import (
 const saltLength = 32
 const saltFile string = "kdf-salt.dat"
 
-// fileInterface implements a unit testing hook for file IO
-type fileInterface interface {
+// file implements a unit testing hook for file IO
+type file interface {
 	io.Reader
 	io.Closer
 	io.WriterAt
@@ -37,7 +37,7 @@ type fileInterface interface {
 
 // defaultKdf stores instance data for the default KDF
 type defaultKdf struct {
-	fileOpener      func(name string, flag int, perm os.FileMode) (fileInterface, error)
+	fileOpener      func(name string, flag int, perm os.FileMode) (file, error)
 	persistencePath string
 	hashConstructor func() hash.Hash
 }
@@ -48,24 +48,24 @@ func NewDefaultKdf(persistencePath string, hashConstructor func() hash.Hash) Key
 }
 
 // defaultFileOpener just opens the file using normal IO
-func defaultFileOpener(name string, flag int, perm os.FileMode) (fileInterface, error) {
+func defaultFileOpener(name string, flag int, perm os.FileMode) (file, error) {
 	return os.OpenFile(name, flag, perm)
 }
 
 // setFileOpener is a test/DI hook to avoid real IO during unit testing
-func (kdf *defaultKdf) setFileOpener(fileOpener func(name string, flag int, perm os.FileMode) (fileInterface, error)) {
+func (kdf *defaultKdf) setFileOpener(fileOpener func(name string, flag int, perm os.FileMode) (file, error)) {
 	kdf.fileOpener = fileOpener
 }
 
 // DeriveKey returns derived key material of specified length
-func (kdf *defaultKdf) DeriveKey(ikm []byte, keylen uint, info string) ([]byte, error) {
+func (kdf *defaultKdf) DeriveKey(ikm []byte, keyLen uint, info string) ([]byte, error) {
 	salt, err := kdf.initializeSalt()
 	if err != nil {
 		return nil, err
 	}
 	infoBytes := []byte(info)
 	kdfreader := hkdf.New(kdf.hashConstructor, ikm, salt, infoBytes)
-	key := make([]byte, keylen)
+	key := make([]byte, keyLen)
 	kdfreader.Read(key)
 	return key, nil
 }

--- a/internal/security/default-kdf/kdf/defaultkdf.go
+++ b/internal/security/default-kdf/kdf/defaultkdf.go
@@ -75,18 +75,18 @@ func (kdf *defaultKdf) DeriveKey(ikm []byte, keyLen uint, info string) ([]byte, 
 func (kdf *defaultKdf) initializeSalt() ([]byte, error) {
 	salt := make([]byte, saltLength)
 	saltPath := path.Join(kdf.persistencePath, saltFile)
-	saltFile, err := kdf.fileOpener(saltPath, os.O_RDWR|os.O_CREATE, 0600)
+	saltFileObj, err := kdf.fileOpener(saltPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err
 	}
-	defer saltFile.Close()
-	nbytes, err := saltFile.Read(salt)
+	defer saltFileObj.Close()
+	nbytes, err := saltFileObj.Read(salt)
 	if nbytes == 0 || nbytes != saltLength {
 		_, err := rand.Read(salt)
 		if err != nil {
 			return nil, err
 		}
-		nwritten, err := saltFile.WriteAt(salt, 0)
+		nwritten, err := saltFileObj.WriteAt(salt, 0)
 		if err != nil || nwritten != len(salt) {
 			return nil, err
 		}

--- a/internal/security/default-kdf/kdf/defaultkdf.go
+++ b/internal/security/default-kdf/kdf/defaultkdf.go
@@ -1,0 +1,95 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package kdf
+
+import (
+	"crypto/rand"
+	"hash"
+	"io"
+	"os"
+	"path"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+const saltLength = 32
+const saltFile string = "kdf-salt.dat"
+
+// fileInterface implements a unit testing hook for file IO
+type fileInterface interface {
+	io.Reader
+	io.Closer
+	io.WriterAt
+}
+
+// defaultKdf stores instance data for the default KDF
+type defaultKdf struct {
+	fileOpener      func(name string, flag int, perm os.FileMode) (fileInterface, error)
+	persistencePath string
+	hashConstructor func() hash.Hash
+}
+
+// NewDefaultKdf creates a new KeyDeriver
+func NewDefaultKdf(persistencePath string, hashConstructor func() hash.Hash) KeyDeriver {
+	return &defaultKdf{defaultFileOpener, persistencePath, hashConstructor}
+}
+
+// defaultFileOpener just opens the file using normal IO
+func defaultFileOpener(name string, flag int, perm os.FileMode) (fileInterface, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+// setFileOpener is a test/DI hook to avoid real IO during unit testing
+func (kdf *defaultKdf) setFileOpener(fileOpener func(name string, flag int, perm os.FileMode) (fileInterface, error)) {
+	kdf.fileOpener = fileOpener
+}
+
+// DeriveKey returns derived key material of specified length
+func (kdf *defaultKdf) DeriveKey(ikm []byte, keylen uint, info string) ([]byte, error) {
+	salt, err := kdf.initializeSalt()
+	if err != nil {
+		return nil, err
+	}
+	infoBytes := []byte(info)
+	kdfreader := hkdf.New(kdf.hashConstructor, ikm, salt, infoBytes)
+	key := make([]byte, keylen)
+	kdfreader.Read(key)
+	return key, nil
+}
+
+// initializeSalt recovers the KDF salt value from a file
+// or installs a new salt
+func (kdf *defaultKdf) initializeSalt() ([]byte, error) {
+	salt := make([]byte, saltLength)
+	saltPath := path.Join(kdf.persistencePath, saltFile)
+	saltFile, err := kdf.fileOpener(saltPath, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	defer saltFile.Close()
+	nbytes, err := saltFile.Read(salt)
+	if nbytes == 0 || nbytes != saltLength {
+		_, err := rand.Read(salt)
+		if err != nil {
+			return nil, err
+		}
+		nwritten, err := saltFile.WriteAt(salt, 0)
+		if err != nil || nwritten != len(salt) {
+			return nil, err
+		}
+	}
+	return salt, nil
+}

--- a/internal/security/default-kdf/kdf/defaultkdf_test.go
+++ b/internal/security/default-kdf/kdf/defaultkdf_test.go
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package kdf
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDefaultKdf tests the default implementation
+func TestDefaultKdf(t *testing.T) {
+	// Arrange
+	keyDeriver := NewDefaultKdf(".", sha256.New, make([]byte, 32))
+	(keyDeriver.(*defaultKdf)).setFileOpener(mockFileOpener) // internal method
+	expected, _ := hex.DecodeString("1060e4e72054653bf46623844033f5ccc9cff596a4a680e074ef4fd06aae60df")
+
+	// Act
+	key, err := keyDeriver.DeriveKey(32, "info")
+
+	// Assert
+	assert.Nil(t, err)
+	assert.Equal(t, expected, key)
+}
+
+//
+// Mock opening and reading of the seed file
+//
+
+func mockFileOpener(name string, flag int, perm os.FileMode) (fileInterface, error) {
+	return &mockSeedFile{}, nil
+}
+
+type mockSeedFile struct{}
+
+func (*mockSeedFile) Close() error {
+	return nil
+}
+
+func (*mockSeedFile) Read(b []byte) (n int, err error) {
+	for i := range b {
+		b[i] = 0
+	}
+	return len(b), nil
+}
+
+func (*mockSeedFile) WriteAt(p []byte, off int64) (n int, err error) {
+	return 32, nil
+}

--- a/internal/security/default-kdf/kdf/defaultkdf_test.go
+++ b/internal/security/default-kdf/kdf/defaultkdf_test.go
@@ -27,12 +27,12 @@ import (
 // TestDefaultKdf tests the default implementation
 func TestDefaultKdf(t *testing.T) {
 	// Arrange
-	keyDeriver := NewDefaultKdf(".", sha256.New, make([]byte, 32))
+	keyDeriver := NewDefaultKdf(".", sha256.New)
 	(keyDeriver.(*defaultKdf)).setFileOpener(mockFileOpener) // internal method
 	expected, _ := hex.DecodeString("1060e4e72054653bf46623844033f5ccc9cff596a4a680e074ef4fd06aae60df")
 
 	// Act
-	key, err := keyDeriver.DeriveKey(32, "info")
+	key, err := keyDeriver.DeriveKey(make([]byte, 32), 32, "info")
 
 	// Assert
 	assert.Nil(t, err)
@@ -43,7 +43,7 @@ func TestDefaultKdf(t *testing.T) {
 // Mock opening and reading of the seed file
 //
 
-func mockFileOpener(name string, flag int, perm os.FileMode) (fileInterface, error) {
+func mockFileOpener(name string, flag int, perm os.FileMode) (file, error) {
 	return &mockSeedFile{}, nil
 }
 

--- a/internal/security/default-kdf/kdf/interface.go
+++ b/internal/security/default-kdf/kdf/interface.go
@@ -18,5 +18,7 @@ package kdf
 // KeyDeriver is the interface that the main program expects
 // for returning a derived key
 type KeyDeriver interface {
-	DeriveKey(ikm []byte, keylen uint, info string) ([]byte, error)
+	// DeriveKey returns a byte array that is of keyLen length and
+	// an error if errors where encountered while deriving the key
+	DeriveKey(ikm []byte, keylkeyLen uint, info string) ([]byte, error)
 }

--- a/internal/security/default-kdf/kdf/interface.go
+++ b/internal/security/default-kdf/kdf/interface.go
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package kdf
+
+// KeyDeriver is the interface that the main program expects
+// for returning a derived key
+type KeyDeriver interface {
+	DeriveKey(ikm []byte, keylen uint, info string) ([]byte, error)
+}

--- a/internal/security/pipedhexreader/interface.go
+++ b/internal/security/pipedhexreader/interface.go
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package pipedhexreader
+
+// PipedHexReader is an interface to read hex bytes from
+// standard output stream of an executable into a byte array
+type PipedHexReader interface {
+	// ReadHexBytesFromExe invokes executable with args
+	// and reads hex bytes from stdout and returns an array
+	ReadHexBytesFromExe(executable string, args []string) ([]byte, error)
+}

--- a/internal/security/pipedhexreader/pipedhexreader.go
+++ b/internal/security/pipedhexreader/pipedhexreader.go
@@ -25,7 +25,7 @@ import (
 )
 
 // pipedHexReader stores instance data for the pipedhexreader
-type pipedHexReader struct { }
+type pipedHexReader struct{}
 
 // NewPipedHexReader creates a new PipedHexReader
 func NewPipedHexReader() PipedHexReader {
@@ -34,7 +34,11 @@ func NewPipedHexReader() PipedHexReader {
 
 // ReadHexBytesFromExe see interface.go
 func (phr *pipedHexReader) ReadHexBytesFromExe(executable string, args []string) ([]byte, error) {
-	cmd := exec.Command(executable, args...)
+	sanitizedExecutable, err := exec.LookPath(executable)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(sanitizedExecutable, args...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err

--- a/internal/security/pipedhexreader/pipedhexreader.go
+++ b/internal/security/pipedhexreader/pipedhexreader.go
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package pipedhexreader
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// pipedHexReader stores instance data for the pipedhexreader
+type pipedHexReader struct { }
+
+// NewPipedHexReader creates a new PipedHexReader
+func NewPipedHexReader() PipedHexReader {
+	return &pipedHexReader{}
+}
+
+// ReadHexBytesFromExe see interface.go
+func (phr *pipedHexReader) ReadHexBytesFromExe(executable string, args []string) ([]byte, error) {
+	cmd := exec.Command(executable, args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(stdout)
+	// We don't WANT a newline, but code defensively
+	hexbytes, _ := reader.ReadString('\n')
+	// Readstring returns non-nil error if delim is not present: ignore this
+	// StdoutPipe usage is to Wait at the end of the reading logic
+	// because it closes the readers automatically
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	// Remove newline if present, the decode hex bytes
+	hexbytes = strings.TrimSuffix(hexbytes, "\n")
+	bytes, err := hex.DecodeString(hexbytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return nil, err
+	}
+	return bytes, nil
+}

--- a/internal/security/pipedhexreader/pipedhexreader_test.go
+++ b/internal/security/pipedhexreader/pipedhexreader_test.go
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package pipedhexreader
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDefaultKdf tests the default implementation
+func TestPipedHexReaderNewline(t *testing.T) {
+	// Arrange
+	phr := NewPipedHexReader()
+	expected, _ := hex.DecodeString("12345678")
+
+	// Act
+	key, err := phr.ReadHexBytesFromExe("echo", []string{"12345678"})
+
+	// Assert
+	assert.Nil(t, err)
+	assert.Equal(t, expected, key)
+}
+
+func TestPipedHexReaderNoNewline(t *testing.T) {
+	// Arrange
+	phr := NewPipedHexReader()
+	expected, _ := hex.DecodeString("12345678")
+
+	// Act
+	key, err := phr.ReadHexBytesFromExe("echo", []string{"-n", "12345678"})
+
+	// Assert
+	assert.Nil(t, err)
+	assert.Equal(t, expected, key)
+}


### PR DESCRIPTION
The default software KDF invokes an IKM_HOOK script for initial
keying material and uses the supplied info argument and a
generated salt value to derive a key that can be used to
encrypt other items in EdgeX.

The security of the KDF depends on the confidentiality of
the input key material; thus, IKM_HOOK should use a robust
method to protect the key material at rest. Other mechanisms
should be used to protect the key material at runtime.

kdf-salt.dat is included so that "go test" generates a valid result

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>