### PR TITLE
[DO NOT MERGE] Implement encryption of Vault master key by user-supplied key.

### DIFF
--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/edgex-go/internal/security/pipedhexreader"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -65,10 +66,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	phr := pipedhexreader.NewPipedHexReader()
 	req := secretstore.NewRequestor(insecureSkipVerify)
 	vaultScheme := secretstore.Configuration.SecretService.Scheme
 	vaultHost := fmt.Sprintf("%s:%v", secretstore.Configuration.SecretService.Server, secretstore.Configuration.SecretService.Port)
-	vc := secretstore.NewVaultClient(req, vaultScheme, vaultHost)
+	vc := secretstore.NewVaultClient(phr, req, vaultScheme, vaultHost)
 	intervalDuration := time.Duration(waitInterval) * time.Second
 	loopExit := false
 

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -72,6 +72,7 @@ Server Options:
 	--init=true/false				Indicates if security service should be initialized	
 	--configfile=<file.toml>			Use a different config file (default: res/configuration.toml)
 	--wait=<time in seconds>		Indicates how long the program will pause between the vault initialization until it succeeds	
+	--allow-vmk-encryption-upgrade=true/false	Allow encryption to be added to an existing Vault master key file
 	Common Options:
 	-h, --help					Show this message
 `

--- a/internal/security/secretstore/certs_test.go
+++ b/internal/security/secretstore/certs_test.go
@@ -43,7 +43,7 @@ func TestGetAccessToken(t *testing.T) {
 		t.Errorf("failed to parse token file")
 		t.Errorf(err.Error())
 	}
-	if s != "test-token" {
+	if s != "s.83AOgsQcSyqhp5OlfMYNj1bh" {
 		t.Errorf("incorrect token")
 		t.Errorf(s)
 	}

--- a/internal/security/secretstore/const.go
+++ b/internal/security/secretstore/const.go
@@ -17,12 +17,14 @@
 package secretstore
 
 const (
-	CertificatesPath = "certificates/"
-	SecurityService  = "securityservice"
-	EdgeXService     = "edgex"
-	VaultToken       = "X-Vault-Token"
-	VaultHealthAPI   = "/v1/sys/health"
-	VaultInitAPI     = "/v1/sys/init"
-	VaultUnsealAPI   = "/v1/sys/unseal"
-	JsonContentType  = "application/json"
+	CertificatesPath     = "certificates/"
+	SecurityService      = "securityservice"
+	EdgeXService         = "edgex"
+	VaultToken           = "X-Vault-Token"
+	VaultHealthAPI       = "/v1/sys/health"
+	VaultInitAPI         = "/v1/sys/init"
+	VaultUnsealAPI       = "/v1/sys/unseal"
+	JsonContentType      = "application/json"
+	PersistDirKdfOption  = "-persistdir"
+	defaultKdfExecutable = "security-defaut-kdf"
 )

--- a/internal/security/secretstore/testdata/test-resp-init-unencrypted.json
+++ b/internal/security/secretstore/testdata/test-resp-init-unencrypted.json
@@ -1,0 +1,1 @@
+{"keys":null,"keys_base64":null,"keys":["66c45ff15d7cf08275a0cbcb78f22d25256bd429f1805ff7e082715be55d194d"],"keys_base64":["NjZjNDVmZjE1ZDdjZjA4Mjc1YTBjYmNiNzhmMjJkMjUyNTZiZDQyOWYxODA1ZmY3ZTA4MjcxNWJlNTVkMTk0ZA=="],"root_token":"s.83AOgsQcSyqhp5OlfMYNj1bh"}

--- a/internal/security/secretstore/testdata/test-resp-init.json
+++ b/internal/security/secretstore/testdata/test-resp-init.json
@@ -1,10 +1,1 @@
-{
-			"keys": [
-			  "test-keys"
-			],
-			"keys_base64": [
-			  "test-keys-base64"
-			],
-			"root_token": "test-root-token"
-		}
-		
+{"keys":null,"keys_base64":null,"encrypted_keys":["d2ddbb0131e9781b4bc78dc60d81da0b48c9afe6b105e08133e853f979e2c21aaf1ab7d7a42d06fe9e816a32e23426ff"],"nonces":["e9bd9dbf33679a8220074ee2"],"root_token":"s.83AOgsQcSyqhp5OlfMYNj1bh"}

--- a/internal/security/secretstore/testdata/test-resp-init.json
+++ b/internal/security/secretstore/testdata/test-resp-init.json
@@ -1,1 +1,1 @@
-{"keys":null,"keys_base64":null,"encrypted_keys":["d2ddbb0131e9781b4bc78dc60d81da0b48c9afe6b105e08133e853f979e2c21aaf1ab7d7a42d06fe9e816a32e23426ff"],"nonces":["e9bd9dbf33679a8220074ee2"],"root_token":"s.83AOgsQcSyqhp5OlfMYNj1bh"}
+{"keys":null,"keys_base64":null,"encrypted_keys":["4a21523b6cb671d32a73b0a45c2b0ed5a23cd59fe160279880bd386bc4c70b795175d5bd3890710e1b65f7aded7d4482"],"nonces":["6f3ebd4f75636d1c2f3a0b6c"],"root_token":"s.83AOgsQcSyqhp5OlfMYNj1bh"}

--- a/internal/security/secretstore/testdata/test-resp-init.json
+++ b/internal/security/secretstore/testdata/test-resp-init.json
@@ -1,1 +1,1 @@
-{"keys":null,"keys_base64":null,"encrypted_keys":["4a21523b6cb671d32a73b0a45c2b0ed5a23cd59fe160279880bd386bc4c70b795175d5bd3890710e1b65f7aded7d4482"],"nonces":["6f3ebd4f75636d1c2f3a0b6c"],"root_token":"s.83AOgsQcSyqhp5OlfMYNj1bh"}
+{"keys":null,"keys_base64":null,"encrypted_keys":["8c4eee278435bb084538ba625791199657b7bfe6daa8c0b243bdf50ab18f3aae"],"nonces":null,"ivs":["c5115f149140c7dc39b417e5d1cb273f"],"root_token":"s.83AOgsQcSyqhp5OlfMYNj1bh"}

--- a/internal/security/secretstore/vault_test.go
+++ b/internal/security/secretstore/vault_test.go
@@ -41,7 +41,7 @@ func TestHealthCheck(t *testing.T) {
 	defer ts.Close()
 
 	host := strings.Replace(ts.URL, "https://", "", -1)
-	vc := NewVaultClient(NewRequestor(true), "https", host)
+	vc := NewVaultClient(newMockPipedHexReader(), NewRequestor(true), "https", host)
 	code, _ := vc.HealthCheck()
 
 	if code != http.StatusOK {
@@ -56,12 +56,12 @@ func TestInit(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{
 			"keys": [
-			  "test-keys"
+			  "66c45ff15d7cf08275a0cbcb78f22d25256bd429f1805ff7e082715be55d194d"
 			],
 			"keys_base64": [
-			  "test-keys-base64"
+			  "NjZjNDVmZjE1ZDdjZjA4Mjc1YTBjYmNiNzhmMjJkMjUyNTZiZDQyOWYxODA1ZmY3ZTA4MjcxNWJlNTVkMTk0ZA=="
 			],
-			"root_token": "test-root-token"
+			"root_token": "s.83AOgsQcSyqhp5OlfMYNj1bh"
 		}
 		`))
 		if r.Method != "POST" {
@@ -81,7 +81,7 @@ func TestInit(t *testing.T) {
 	}
 
 	host := strings.Replace(ts.URL, "https://", "", -1)
-	vc := NewVaultClient(NewRequestor(true), "https", host)
+	vc := NewVaultClient(newMockPipedHexReader(), NewRequestor(true), "https", host)
 	code, _ := vc.Init()
 	if code != http.StatusOK {
 		t.Errorf("incorrect vault init status. The returned code is %d", code)
@@ -112,9 +112,23 @@ func TestUnseal(t *testing.T) {
 	}
 
 	host := strings.Replace(ts.URL, "https://", "", -1)
-	vc := NewVaultClient(NewRequestor(true), "https", host)
+	vc := NewVaultClient(newMockPipedHexReader(), NewRequestor(true), "https", host)
 	code, err := vc.Unseal()
 	if code != http.StatusOK {
 		t.Errorf("incorrect vault unseal status. The returned code is %d, %s", code, err.Error())
 	}
+}
+
+//
+// Test mocks
+//
+
+type mockPipedHexReader struct{}
+
+func newMockPipedHexReader() *mockPipedHexReader {
+	return &mockPipedHexReader{}
+}
+
+func (*mockPipedHexReader) ReadHexBytesFromExe(executable string, args []string) ([]byte, error) {
+	return make([]byte, 32), nil
 }


### PR DESCRIPTION
User supplied key is obtained by calling a key derivation hook
($KDF_HOOK -persistdir path) and expecting a 32-byte hex-encoded key.
If $KDF_HOOK is undefined, will attempt to locate an execute
'security-default-kdf' on the PATH.  The resulting key is used
for AES-256-GCM encryption of the key shares with a random
nonce for each key share.

The init-resp.json file is modified by removing Keys and
KeysBase64 fields and replacing them with EncryptedKeys and Nonces
fields, and the reverse is done upon decryption.  No decryption
is done if the init-resp.json already contains a KeysBase64 field.

This pull request is blocked because `security-secretstore-setup` is not yet
merged into `edgex-go`.  Also this change needs integration testing.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>