### PR TITLE
[DO NOT MERGE] Fixes #1677 by creating cmd/security-file-token-provider.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOCGO=CGO_ENABLED=1 GO111MODULE=on go
 DOCKERS=docker_config_seed docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent docker_support_scheduler docker_security_secrets_setup docker_security_proxy_setup docker_security_secretstore_setup
 .PHONY: $(DOCKERS)
 
-MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup cmd/security-secretstore-setup/security-secretstore-setup
+MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup cmd/security-secretstore-setup/security-secretstore-setup cmd/security-file-token-provider/security-file-token-provider
 
 .PHONY: $(MICROSERVICES)
 
@@ -70,6 +70,8 @@ cmd/security-proxy-setup/security-proxy-setup:
 cmd/security-secretstore-setup/security-secretstore-setup:
 	$(GO) build $(GOFLAGS) -o ./cmd/security-secretstore-setup/security-secretstore-setup ./cmd/security-secretstore-setup
 
+cmd/security-file-token-provider/security-file-token-provider:
+	$(GO) build $(GOFLAGS) -o ./cmd/security-file-token-provider/security-file-token-provider ./cmd/security-file-token-provider
 
 clean:
 	rm -f $(MICROSERVICES)

--- a/cmd/security-file-token-provider/Attribution.txt
+++ b/cmd/security-file-token-provider/Attribution.txt
@@ -1,0 +1,146 @@
+The following open source projects are referenced by Security Secrets Setup:
+
+pkg/errors (BSD-2) https://github.com/pkg/errors
+https://github.com/pkg/errors/blob/master/LICENSE
+
+gorilla/mux (BSD-3) - https://github.com/gorilla/mux
+https://github.com/gorilla/mux/blob/master/LICENSE
+
+globalsign/mgo (unspecified) - https://github.com/globalsign/mgo
+https://github.com/globalsign/mgo/blob/master/LICENSE
+
+pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
+https://github.com/pebbe/zmq4/blob/master/LICENSE.txt
+
+go-kit/kit (MIT) github.com/go-kit/kit
+https://github.com/go-kit/kit/blob/master/LICENSE
+
+go-logfmt/logfmt (MIT) https://github.com/go-logfmt/logfmt
+https://github.com/go-logfmt/logfmt/blob/master/LICENSE
+
+robfig/cron (MIT) https://github.com/robfig/cron
+https://github.com/robfig/cron/blob/master/LICENSE
+
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
+google/uuid (BSD-3) https://github.com/google/uuid
+https://github.com/google/uuid/blob/master/LICENSE
+
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
+influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
+https://github.com/influxdata/influxdb/blob/master/LICENSE
+
+influxdata/platform (MIT) https://github.com/influxdata/platform
+https://github.com/influxdata/platform/blob/master/LICENSE
+
+eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
+https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
+
+mattn/go-xmpp (BSD-3) https://github.com/mattn/go-xmpp
+https://github.com/mattn/go-xmpp/blob/master/LICENSE
+
+BurntSushi/toml (MIT) https://github.com/BurntSushi/toml
+https://github.com/BurntSushi/toml/blob/master/COPYING
+
+mitchellh/consulstructure (MIT) https://github.com/mitchellh/consulstructure
+https://github.com/mitchellh/consulstructure/blob/master/LICENSE
+
+mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
+https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+mitchellh/copystructure (MIT) https://github.com/mitchellh/copystructure
+https://github.com/mitchellh/copystructure/blob/master/LICENSE
+
+mitchellh/reflectwalk (MIT) https://github.com/mitchellh/reflectwalk
+https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
+
+cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
+https://github.com/cenkalti/backoff/blob/master/LICENSE
+
+hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+https://github.com/hashicorp/consul/blob/master/LICENSE
+
+hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
+https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
+
+hashicorp/go-rootcerts (Mozilla Public License 2.0) https://github.com/hashicorp/go-rootcerts
+https://github.com/hashicorp/go-rootcerts/blob/master/LICENSE
+
+mitchellh/go-homedir (MIT) https://github.com/mitchellh/go-homedir
+https://github.com/mitchellh/go-homedir/blob/master/LICENSE
+
+mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
+https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+hashicorp/serf (Mozilla Public License 2.0) https://github.com/hashicorp/serf
+https://github.com/hashicorp/serf/blob/master/LICENSE
+
+armon/go-metrics (MIT) https://github.com/armon/go-metrics
+https://github.com/armon/go-metrics/blob/master/LICENSE
+
+hashicorp/go-immutable-radix (Mozilla Public License 2.0) https://github.com/hashicorp/go-immutable-radix
+https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
+
+hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
+https://github.com/hashicorp/golang-lru/blob/master/LICENSE
+
+gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
+https://github.com/gomodule/redigo/blob/master/LICENSE
+
+OneOfOne/xxhash (Apache 2.0) https://github.com/OneOfOne/xxhash
+https://github.com/OneOfOne/xxhash/blob/master/LICENSE
+
+imdario/mergo (BSD-3) github.com/imdario/mergo
+https://github.com/imdario/mergo/blob/master/LICENSE
+
+magiconair/properties (BSD-2) https://github.com/magiconair/properties
+https://github.com/magiconair/properties/blob/master/LICENSE
+
+gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
+https://github.com/eapache/queue/blob/v1.1.0/LICENSE
+
+bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
+https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
+https://github.com/hashicorp/consul/blob/master/LICENSE
+

--- a/cmd/security-file-token-provider/README.md
+++ b/cmd/security-file-token-provider/README.md
@@ -1,0 +1,57 @@
+# Integration testing instructions for security-file-token-provider
+
+## Build
+
+Use Makefile in the base directory of this repository to build the docker image of security-secretes-setup:
+
+```sh
+make -C ../.. cmd/security-file-token-provider/security-file-token-provider
+```
+
+It should create an executable named `security-file-token-provider` in the current directory.
+
+## Run
+
+Run the `integrationtest.sh` script.
+
+```sh
+./integrationtest.sh
+```
+
+Verify the resulting output for correctness.
+The script will automatically fail if a subcommand
+returns a nonzero exit status.
+
+Afterwards, shut down the docker composition
+
+```sh
+docker-compose down
+```
+
+## Details
+
+The integration test script first starts Vault and Consul via a docker-compose.yml script.
+The script copies out the CA certificate and root token JSON file to the current directory.
+It then overwrites `res/configuration.toml` with some values to allow the integration test to run.
+The script then dumps a list of all policies, and a list of current Vault tokens.
+
+Next, the script runs `security-file-token-provider`
+
+Afterwards, the script then dumps the policies, Vault tokens,
+the policy it just created, and calls the token lookup command
+on the newly-created Vault token.
+
+## Testing with TLS
+
+In order to test with TLS, it is necessary to edit `/etc/hosts` and add
+an alias for edgex-vault:
+
+```
+127.0.0.1 edgex-vault
+```
+
+Then edit `integrationtest.sh` and uncomment `CaFilePath`.
+
+Re-run `integrationtest.sh` and verify that it makes a TLS connection to Vault.
+
+_BE SURE TO REMOVE THE EDITS FROM `/etc/hosts` WHEN YOU ARE DONE!_

--- a/cmd/security-file-token-provider/docker-compose.yml
+++ b/cmd/security-file-token-provider/docker-compose.yml
@@ -1,0 +1,119 @@
+# /*******************************************************************************
+#  * Copyright 2018 Dell Inc.
+#  * Copyright 2019 Intel Corporation
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  * @author: Jim White, Dell
+#  * EdgeX Foundry, Delhi version, 0.7.1
+#  * added: Dec 10, 2018
+#  *******************************************************************************/
+
+version: '3'
+volumes:
+  db-data:
+  log-data:
+  consul-config:
+  consul-data:
+  vault-config:
+  vault-file:
+  vault-logs:
+
+services:
+  volume:
+    image: edgexfoundry/docker-edgex-volume:0.6.0
+    container_name: edgex-files
+    networks:
+      - edgex-network
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+      
+  consul:
+    image: consul:1.4.4
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:8600"
+    container_name: edgex-core-consul
+    hostname: edgex-core-consul
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-consul
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume  
+
+  config-seed:
+    image: edgexfoundry/docker-core-config-seed-go:0.7.1
+    container_name: edgex-config-seed
+    hostname: edgex-core-config-seed
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-config-seed
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume
+      - consul
+
+  vault:
+    image: edgexfoundry/docker-edgex-vault:1.0.0
+    container_name: edgex-vault
+    hostname: edgex-vault
+    networks:
+      - edgex-network
+    ports:
+      - "8200:8200"
+    cap_add:
+      - "IPC_LOCK"
+    command: "server -log-level=info"
+    environment:
+      - 'VAULT_ADDR=https://edgex-vault:8200'
+      - 'VAULT_CONFIG_DIR=/vault/config'
+      - 'VAULT_UI=true'
+    volumes:
+      - vault-config:/vault/config
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
+    depends_on:
+      - volume
+      - consul
+
+  vault-worker:
+    image: edgexfoundry/docker-edgex-vault-worker-go:1.0.0
+    container_name: edgex-vault-worker
+    hostname: edgex-vault-worker
+    command: ["--init=true", "--debug=false", "--wait=10", "--insureskipverify=false"]
+    networks:
+      - edgex-network
+    volumes:
+      - vault-config:/vault/config
+    depends_on:
+      - volume
+      - consul
+      - vault  
+
+networks:
+  edgex-network:
+    driver: "bridge"
+...

--- a/cmd/security-file-token-provider/integrationtest.sh
+++ b/cmd/security-file-token-provider/integrationtest.sh
@@ -1,0 +1,77 @@
+#!/bin/sh -e
+
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0'
+#
+
+make -C ../.. cmd/security-file-token-provider/security-file-token-provider
+
+docker-compose up -d
+
+echo 'Waiting for stack to come up...'
+sleep 5
+
+vaultid=`docker ps | grep 'edgexfoundry/docker-edgex-vault' | cut -d' ' -f1`
+echo "Vault container id $vaultid"
+
+docker exec $vaultid cat /vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem > EdgeXFoundryCA.pem
+docker exec $vaultid cat /vault/config/assets/resp-init.json > resp-init.json
+
+vault_token=`jq -r .root_token ./resp-init.json`
+echo "Vault root token is $vault_token"
+
+cat <<EOH > res/configuration.toml
+[SecretService]
+Scheme = "https"
+Server = "localhost"
+Port = 8200
+# CaFilePath = "EdgeXFoundryCA.pem"
+
+[TokenFileProvider]
+PrivilegedTokenPath = "resp-init.json"
+ConfigFile = "res/token-config.json"
+OutputDir = "/tmp"
+OutputFilename = "secrets-token.json"
+
+[Writable]
+LogLevel = 'DEBUG'
+
+[Logging]
+EnableRemote = false
+File = './logs/security-file-token-provider.log'
+EOH
+
+echo "---==[ BEFORE policies ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault policy list -tls-skip-verify
+
+echo "---==[ BEFORE tokens ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault list -tls-skip-verify auth/token/accessors
+
+./security-file-token-provider
+
+echo "---==[ AFTER policies ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault policy list -tls-skip-verify
+
+echo "---==[ AFTER policy (dump edgex-service-service-name) ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault policy read -tls-skip-verify edgex-service-service-name
+
+echo "---==[ AFTER tokens ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault list -tls-skip-verify auth/token/accessors
+
+new_token=`jq -r .auth.client_token /tmp/service-name/secrets-token.json`
+
+echo "---==[ INFO on new token ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$new_token" $vaultid vault token lookup -tls-skip-verify
+

--- a/cmd/security-file-token-provider/main.go
+++ b/cmd/security-file-token-provider/main.go
@@ -1,0 +1,129 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenreader"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
+	"github.com/edgexfoundry/edgex-go/internal/security/tokenconfig"
+	"github.com/edgexfoundry/edgex-go/internal/security/vaultclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+// Constants
+
+// Dependencies
+
+var exitInstance = newExit()
+var fileProvider fileprovider.TokenProvider
+
+// Flag variables
+
+var helpOpt bool
+var useProfile string
+var useRegistry bool
+
+// define and register command line flags
+func init() {
+	flag.BoolVar(&helpOpt, "h", false, "help message")
+	flag.BoolVar(&helpOpt, "help", false, "help message")
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
+	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+}
+
+func main() {
+	flag.Parse()
+
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	startup.Bootstrap(params, fileprovider.Retry, logBeforeInit)
+
+	if helpOpt {
+		flag.Usage()
+		exitInstance.callExit(0)
+		return
+	}
+
+	cfg := fileprovider.Configuration     // Global variable initialized in fileprovider.Retry
+	logging := fileprovider.LoggingClient // Global variable initialized in fileprovider.Retry
+
+	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
+	tokenProvider := authtokenreader.NewAuthTokenReader(fileOpener)
+	tokenConfigParser := tokenconfig.NewTokenConfigParser(fileOpener)
+
+	var req vaultclient.Requestor
+	if caFilePath := cfg.SecretService.CaFilePath; caFilePath != "" {
+		logging.Info("using certificate verification for secret store connection")
+		caReader, err := fileOpener.OpenFileReader(caFilePath, os.O_RDONLY, 0400)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			exitInstance.callExit(1)
+			return
+		}
+		req = vaultclient.NewRequestor(logging).WithCaCert(caReader)
+	} else {
+		logging.Info("bypassing certificate verification for secret store connection")
+		req = vaultclient.NewRequestor(logging).Insecure()
+	}
+	vaultScheme := cfg.SecretService.Scheme
+	vaultHost := fmt.Sprintf("%s:%v", cfg.SecretService.Server, cfg.SecretService.Port)
+	vaultClient := vaultclient.NewVaultClient(logging, req, vaultScheme, vaultHost)
+
+	if fileProvider == nil {
+		// main_test.go has injected a testing mock if fileProvider != nil
+		fileProvider = fileprovider.NewTokenProvider(logging, fileOpener, tokenProvider, tokenConfigParser, vaultClient)
+	}
+
+	fileProvider.SetConfiguration(cfg.SecretService, cfg.TokenFileProvider)
+	err := fileProvider.Run()
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exitInstance.callExit(1)
+		return
+	}
+
+	exitInstance.callExit(0)
+}
+
+func logBeforeInit(err error) {
+	l := logger.NewClient("security-proxy-setup", false, "", models.InfoLog)
+	l.Error(err.Error())
+}
+
+type exit interface {
+	callExit(int)
+}
+
+type exitCode struct{}
+
+func newExit() exit {
+	return &exitCode{}
+}
+
+func (*exitCode) callExit(statusCode int) {
+	os.Exit(statusCode)
+}

--- a/cmd/security-file-token-provider/main_test.go
+++ b/cmd/security-file-token-provider/main_test.go
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileprovider/mocks"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type testExitCode struct {
+	testStatusCode int
+}
+
+func newTestExit() exit {
+	return &testExitCode{}
+}
+
+func (testExit *testExitCode) callExit(statusCode int) {
+	testExit.testStatusCode = statusCode
+}
+
+func (testExit *testExitCode) getStatusCode() int {
+	return testExit.testStatusCode
+}
+
+// WcaptureWrapper wraps a lambda function to preserve os.Args and capture (and return) stdin and stdout
+func captureWrapper(t *testing.T, delegate func(t *testing.T) error) (bytes.Buffer, bytes.Buffer, error) {
+	var oldArgs []string
+	var oldStdout, oldStderr *os.File
+	var oldFileProvider fileprovider.TokenProvider
+	var stdoutReader, stdoutWriter *os.File
+	var stderrReader, stderrWriter *os.File
+	var stdoutCapture, stderrCapture bytes.Buffer
+
+	var preFunc = func(t *testing.T) {
+		exitInstance = newTestExit()
+		oldArgs, oldStdout, oldStderr = os.Args, os.Stdout, os.Stderr
+		stdoutReader, stdoutWriter, _ = os.Pipe()
+		stderrReader, stderrWriter, _ = os.Pipe()
+		os.Stdout, os.Stderr = stdoutWriter, stderrWriter
+		stdoutCapture.Reset()
+		stderrCapture.Reset()
+	}
+	var postFunc = func(t *testing.T) {
+		stdoutWriter.Close()
+		stderrWriter.Close()
+		io.Copy(&stdoutCapture, stdoutReader)
+		io.Copy(&stderrCapture, stderrReader)
+		os.Args, os.Stdout, os.Stderr = oldArgs, oldStdout, oldStderr
+		fileProvider = oldFileProvider
+	}
+
+	lambda := func(t *testing.T) error {
+		preFunc(t)
+		defer postFunc(t)
+		err := delegate(t)
+		return err
+	}
+
+	err := lambda(t)
+	return stdoutCapture, stderrCapture, err
+}
+
+func TestNoOption(t *testing.T) {
+	assert := assert.New(t)
+
+	mockTokenProvider := &MockTokenProvider{}
+	mockTokenProvider.On("Run").Return(nil)
+	mockTokenProvider.On("SetConfiguration", mock.Anything, mock.Anything).Once()
+
+	_, stderrCapture, err := captureWrapper(t, func(t *testing.T) error {
+		os.Args = []string{"cmd"}
+		fileProvider = mockTokenProvider // fileProvider is global in main.go
+		main()
+		return nil
+	})
+
+	assert.Nil(err)
+	mockTokenProvider.AssertExpectations(t)
+	assert.Equal(0, (exitInstance.(*testExitCode)).getStatusCode())
+	assert.Equal("", stderrCapture.String())
+}

--- a/cmd/security-file-token-provider/res/configuration.toml
+++ b/cmd/security-file-token-provider/res/configuration.toml
@@ -1,0 +1,18 @@
+[SecretService]
+Scheme = "https"
+Server = "localhost"
+Port = 8200
+# CaFilePath = "EdgeXFoundryCA.pem"
+
+[TokenFileProvider]
+PrivilegedTokenPath = "resp-init.json"
+ConfigFile = "res/token-config.json"
+OutputDir = "/tmp"
+OutputFilename = "secrets-token.json"
+
+[Writable]
+LogLevel = 'DEBUG'
+
+[Logging]
+EnableRemote = false
+File = './logs/security-file-token-provider.log'

--- a/cmd/security-file-token-provider/res/token-config.json
+++ b/cmd/security-file-token-provider/res/token-config.json
@@ -1,0 +1,13 @@
+{
+    "service-name": {
+      "edgex_use_defaults": true,
+      "custom_policy": {
+        "path": {
+          "secret/non/standard/location/*": {
+            "capabilities": [ "list", "read" ]
+          }
+        }
+      },
+      "custom_token_parameters": { }
+    }
+  }

--- a/internal/security/authtokenreader/interface.go
+++ b/internal/security/authtokenreader/interface.go
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenreader
+
+// AuthTokenReader returns authorization token for secret store
+type AuthTokenReader interface {
+	// Load loads authorization token
+	Load(path string) error
+	// AuthToken returns authorization token
+	AuthToken() string
+}

--- a/internal/security/authtokenreader/methods.go
+++ b/internal/security/authtokenreader/methods.go
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenreader
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+)
+
+type tokenProvider struct {
+	fileOpener fileioperformer.FileIoPerformer
+	authToken  string
+}
+
+// NewAuthTokenReader creates a new TokenParser
+func NewAuthTokenReader(opener fileioperformer.FileIoPerformer) AuthTokenReader {
+	return &tokenProvider{fileOpener: opener}
+}
+
+func (p *tokenProvider) Load(path string) error {
+	reader, err := p.fileOpener.OpenFileReader(path, os.O_RDONLY, 0400)
+	if err != nil {
+		return err
+	}
+	readCloser := fileioperformer.MakeReadCloser(reader)
+	fileContents, err := ioutil.ReadAll(readCloser)
+	if err != nil {
+		return err
+	}
+	defer readCloser.Close()
+
+	var parsedContents vaultTokenFile
+	err = json.Unmarshal(fileContents, &parsedContents)
+	if err != nil {
+		return err
+	}
+
+	// Look for token first in "auth"/"client_token"
+	// and then in "root_token"
+	// and fail if no token is found at all
+	p.authToken = parsedContents.Auth.ClientToken
+	if p.authToken == "" {
+		p.authToken = parsedContents.RootToken
+	}
+	if p.authToken == "" {
+		return fmt.Errorf("Unable to find authentication token in %s", path)
+	}
+	return nil
+}
+
+func (p *tokenProvider) AuthToken() string {
+	return p.authToken
+}

--- a/internal/security/authtokenreader/methods_test.go
+++ b/internal/security/authtokenreader/methods_test.go
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenreader
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileioperformer/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+const createTokenJSON = `{"auth":{"client_token":"some-token-value"}}`
+const vaultInitJSON = `{"root_token":"some-token-value"}`
+const expectedToken = "some-token-value"
+
+func TestReadCreateTokenJSON(t *testing.T) {
+	stringReader := strings.NewReader(createTokenJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewAuthTokenReader(mockFileIoPerformer)
+
+	err := p.Load("/dev/null")
+	assert.Nil(t, err)
+
+	token := p.AuthToken()
+	assert.Equal(t, expectedToken, token)
+}
+
+func TestReadVaultInitJSON(t *testing.T) {
+	stringReader := strings.NewReader(vaultInitJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewAuthTokenReader(mockFileIoPerformer)
+
+	err := p.Load("/dev/null")
+	assert.Nil(t, err)
+
+	token := p.AuthToken()
+	assert.Equal(t, expectedToken, token)
+}
+
+func TestReadEmptyJSON(t *testing.T) {
+	stringReader := strings.NewReader("{}")
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewAuthTokenReader(mockFileIoPerformer)
+
+	err := p.Load("/dev/null")
+	assert.NotNil(t, err)
+}
+
+func TestFailOpen(t *testing.T) {
+	stringReader := strings.NewReader("")
+	myerr := errors.New("error")
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, myerr)
+
+	p := NewAuthTokenReader(mockFileIoPerformer)
+
+	err := p.Load("/dev/null")
+	assert.Equal(t, myerr, err)
+}

--- a/internal/security/authtokenreader/mocks/mock.go
+++ b/internal/security/authtokenreader/mocks/mock.go
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type MockAuthTokenReader struct {
+	mock.Mock
+}
+
+func (m *MockAuthTokenReader) Load(path string) error {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(path)
+	return arguments.Error(0)
+}
+
+func (m *MockAuthTokenReader) AuthToken() string {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called()
+	return arguments.String(0)
+}

--- a/internal/security/authtokenreader/mocks/mock_test.go
+++ b/internal/security/authtokenreader/mocks/mock_test.go
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/authtokenreader"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface AuthTokenReader = &MockAuthTokenReader{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockLoad(t *testing.T) {
+	o := &MockAuthTokenReader{}
+	o.On("Load", "path").Return(nil)
+
+	err := o.Load("path")
+
+	o.AssertExpectations(t)
+	assert.Nil(t, err)
+}
+
+func TestMockAuthToken(t *testing.T) {
+	o := &MockAuthTokenReader{}
+	o.On("AuthToken").Return("")
+
+	token := o.AuthToken()
+
+	o.AssertExpectations(t)
+	assert.Equal(t, "", token)
+}

--- a/internal/security/authtokenreader/types.go
+++ b/internal/security/authtokenreader/types.go
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenreader
+
+type vaultTokenFile struct {
+	// Auth comes from the create token API
+	Auth authObject `json:"auth"`
+	// RootToken comes from the vault-init response
+	RootToken string `json:"root_token"`
+}
+
+type authObject struct {
+	ClientToken string `json:"client_token"`
+}

--- a/internal/security/fileioperformer/fileioperformer.go
+++ b/internal/security/fileioperformer/fileioperformer.go
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileioperformer
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type defaultFileIoPerformer struct{}
+
+func NewDefaultFileIoPerformer() FileIoPerformer {
+	return &defaultFileIoPerformer{}
+}
+
+func (*defaultFileIoPerformer) OpenFileReader(name string, flag int, perm os.FileMode) (io.Reader, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (*defaultFileIoPerformer) OpenFileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (*defaultFileIoPerformer) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// MakeReadCloser will turn an an io.Reader into an io.ReadCloser
+// if the underlying object does not already support io.ReadCloser
+func MakeReadCloser(reader io.Reader) io.ReadCloser {
+	rc, ok := reader.(io.ReadCloser)
+	if !ok && reader != nil {
+		rc = ioutil.NopCloser(reader)
+	}
+	return rc
+}

--- a/internal/security/fileioperformer/fileioperformer_test.go
+++ b/internal/security/fileioperformer/fileioperformer_test.go
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileioperformer
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//
+// Note: these tests do real I/O.
+// Filenames are chosen so as to make this I/O harmless
+//
+
+func TestFileIoPerformerReader(t *testing.T) {
+
+	fileio := NewDefaultFileIoPerformer()
+
+	reader, err := fileio.OpenFileReader("/dev/null", os.O_RDONLY, 0400)
+	assert.Nil(t, err)
+	assert.NotNil(t, fileio)
+	assert.NotNil(t, reader)
+}
+
+func TestFileIoPerformerWriter(t *testing.T) {
+
+	fileio := NewDefaultFileIoPerformer()
+
+	writer, err := fileio.OpenFileWriter("/dev/null", os.O_RDONLY, 0400)
+	assert.Nil(t, err)
+	assert.NotNil(t, fileio)
+	assert.NotNil(t, writer)
+}
+
+func TestFileIoPerformerMkdirAll(t *testing.T) {
+
+	fileio := NewDefaultFileIoPerformer()
+
+	err := fileio.MkdirAll("/tmp", 0777)
+	assert.Nil(t, err)
+}
+
+func TestMakeReadCloserPassThru(t *testing.T) {
+
+	var mockReadCloser io.ReadCloser = &mockReadCloser{}
+	var mockReader = mockReadCloser.(io.Reader)
+
+	result := MakeReadCloser(mockReader)
+	result2 := MakeReadCloser(mockReadCloser)
+
+	// In all cases, should just get the original object back
+
+	assert.Implements(t, (*io.ReadCloser)(nil), result)
+	assert.Implements(t, (*io.ReadCloser)(nil), result2)
+
+	assert.Equal(t, mockReadCloser, result)
+	assert.Equal(t, mockReadCloser, result2)
+}
+
+func TestMakeReadCloserNopCloser(t *testing.T) {
+
+	var mockReader = &mockReader{}
+
+	result := MakeReadCloser(mockReader)
+
+	// Should get back an object with a NopCloser wrapper
+
+	assert.Implements(t, (*io.ReadCloser)(nil), result)
+}
+
+//
+// mocking support
+//
+
+type mockReadCloser struct{}
+
+func (rc *mockReadCloser) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (rc *mockReadCloser) Close() error {
+	return nil
+}
+
+type mockReader struct{}
+
+func (rc *mockReader) Read(p []byte) (n int, err error) {
+	return 0, nil
+}

--- a/internal/security/fileioperformer/interface.go
+++ b/internal/security/fileioperformer/interface.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileioperformer
+
+import (
+	"io"
+	"os"
+)
+
+type FileIoPerformer interface {
+	// OpenFileReader is a function that opens a file and returns an io.Reader (at a minumum)
+	OpenFileReader(name string, flag int, perm os.FileMode) (io.Reader, error)
+	// OpenFileWriter is a function that opens a file and returns an io.WriteCloser (at a minumum)
+	OpenFileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error)
+	// MkdirAll creates a directory tree (see os.MkdirAll)
+	MkdirAll(path string, perm os.FileMode) error
+}

--- a/internal/security/fileioperformer/mocks/mock.go
+++ b/internal/security/fileioperformer/mocks/mock.go
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"io"
+	"os"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockFileIoPerformer struct {
+	mock.Mock
+}
+
+func (m *MockFileIoPerformer) OpenFileReader(name string, flag int, perm os.FileMode) (io.Reader, error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(name, flag, perm)
+	return arguments.Get(0).(io.Reader), arguments.Error(1)
+}
+
+func (m *MockFileIoPerformer) OpenFileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(name, flag, perm)
+	return arguments.Get(0).(io.WriteCloser), arguments.Error(1)
+}
+
+func (m *MockFileIoPerformer) MkdirAll(path string, perm os.FileMode) error {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(path, perm)
+	return arguments.Error(0)
+}

--- a/internal/security/fileioperformer/mocks/mock_test.go
+++ b/internal/security/fileioperformer/mocks/mock_test.go
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface FileIoPerformer = &MockFileIoPerformer{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockOpenFileReader(t *testing.T) {
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(&fakeReaderWriter{}, nil)
+
+	obj, err := mockFileIoPerformer.OpenFileReader("/dev/null", os.O_RDONLY, os.FileMode(0400))
+	assert.NotNil(t, obj)
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+}
+
+func TestMockOpenFileWriter(t *testing.T) {
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileWriter", "/dev/null", os.O_WRONLY, os.FileMode(0500)).Return(&fakeReaderWriter{}, nil)
+
+	obj, err := mockFileIoPerformer.OpenFileWriter("/dev/null", os.O_WRONLY, os.FileMode(0500))
+	assert.NotNil(t, obj)
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+}
+
+func TestMockMkdirAll(t *testing.T) {
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("MkdirAll", "/tmp/foo", os.FileMode(0700)).Return(nil)
+
+	err := mockFileIoPerformer.MkdirAll("/tmp/foo", os.FileMode(0700))
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+}
+
+//
+// fakes
+//
+
+type fakeReaderWriter struct{}
+
+func (*fakeReaderWriter) Close() error {
+	return nil
+}
+
+func (m *fakeReaderWriter) Read(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (m *fakeReaderWriter) Write(p []byte) (n int, err error) {
+	return 0, nil
+}

--- a/internal/security/fileprovider/config.go
+++ b/internal/security/fileprovider/config.go
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+)
+
+type ConfigurationStruct struct {
+	Writable          WritableInfo
+	Logging           config.LoggingInfo
+	SecretService     SecretServiceInfo
+	TokenFileProvider TokenFileProviderInfo
+	Clients           map[string]config.ClientInfo
+}
+
+type WritableInfo struct {
+	LogLevel string
+}

--- a/internal/security/fileprovider/const.go
+++ b/internal/security/fileprovider/const.go
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+const (
+	SnapNameEnvVar             = "SNAP_NAME"
+	DefaultVaultServer         = "edgex-vault"
+	DefaultVaultServerSnap     = "localhost"
+	DefaultVaultPort           = 8200
+	DefaultPrivilegedTokenPath = "/run/edgex/secrets/token-file-provider/secrets-token.json"
+	DefaultConfigFile          = "res/token-config.json"
+	DefaultOutputDir           = "/run/edgex/secrets"
+	DefaultOutputFilename      = "secrets-token.json"
+	VaultTokenHeader           = "X-Vault-Token"
+)

--- a/internal/security/fileprovider/defaults.go
+++ b/internal/security/fileprovider/defaults.go
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"encoding/json"
+)
+
+func makeDefaultTokenPolicy(serviceName string) map[string]interface{} {
+	protectedPath := "secret/edgex/" + serviceName + "/*"
+	capabilities := []string{"create", "update", "delete", "list", "read"}
+	acl := struct {
+		Capabilities []string `json:"capabilities"`
+	}{
+		Capabilities: capabilities,
+	}
+	pathObject := map[string]interface{}{protectedPath: acl}
+	entry := struct {
+		Path interface{} `json:"path"`
+	}{
+		Path: pathObject,
+	}
+
+	// Marshal the data and then unmarshal it again to turn it into an opaque data structure
+
+	bytes, err := json.Marshal(entry)
+	if err != nil {
+		panic(err) // We are in control; should never happen
+	}
+
+	retval := make(map[string]interface{})
+	json.Unmarshal(bytes, &retval)
+	return retval
+
+	/*
+		{
+			"path": {
+			  "secret/edgex/service-name/*": {
+				"capabilities": [ "create", "update", "delete", "list", "read" ]
+			  }
+			}
+		  }
+	*/
+}
+
+func makeDefaultTokenParameters(serviceName string) map[string]interface{} {
+	policyName := "edgex-service-" + serviceName
+	data := struct {
+		DisplayName string   `json:"display_name"`
+		NoParent    bool     `json:"no_parent"`
+		Policies    []string `json:"policies"`
+	}{
+		DisplayName: serviceName,
+		NoParent:    true,
+		Policies:    []string{policyName},
+	}
+
+	// Marshal the data and then unmarshal it again to turn it into an opaque data structure
+
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		panic(err) // We are in control; should never happen
+	}
+
+	var retval map[string]interface{}
+	json.Unmarshal(bytes, &retval)
+	return retval
+}

--- a/internal/security/fileprovider/defaults_test.go
+++ b/internal/security/fileprovider/defaults_test.go
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package fileprovider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultTokenPolicy(t *testing.T) {
+	// Arrange
+
+	// Act
+	policies := makeDefaultTokenPolicy("service-name")
+
+	// Assert
+	bytes, err := json.Marshal(policies)
+	if err != nil {
+		panic(err)
+	}
+
+	expected := `{"path":{"secret/edgex/service-name/*":{"capabilities":["create","update","delete","list","read"]}}}`
+	actual := string(bytes)
+	assert.Equal(t, expected, actual)
+}
+
+func TestDefaultTokenParameters(t *testing.T) {
+	// Arrange
+
+	// Act
+	parameters := makeDefaultTokenParameters("service-name")
+
+	// Assert
+	bytes, err := json.Marshal(parameters)
+	if err != nil {
+		panic(err)
+	}
+
+	expected := `{"display_name":"service-name","no_parent":true,"policies":["edgex-service-service-name"]}`
+	actual := string(bytes)
+	assert.Equal(t, expected, actual)
+}

--- a/internal/security/fileprovider/init.go
+++ b/internal/security/fileprovider/init.go
@@ -1,0 +1,83 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"sync"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// Global variables
+var Configuration *ConfigurationStruct
+var LoggingClient logger.LoggingClient
+
+func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
+	for time.Now().Before(until) {
+		var err error
+		// When looping, only handle configuration if it hasn't already been set.
+		if Configuration == nil {
+			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			if err != nil {
+				ch <- err
+				if !useRegistry {
+					// Error occurred when attempting to read from local filesystem. Fail fast.
+					close(ch)
+					wait.Done()
+					return
+				}
+			} else {
+				// Setup Logging
+				logTarget := setLoggingTarget()
+				LoggingClient = logger.NewClient(internal.SecurityProxySetupServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+			}
+		}
+		// This seems a bit artificial here due to lack of additional service requirements
+		// but conforms to the pattern found in other edgex-go services.
+		if Configuration != nil {
+			break
+		}
+		time.Sleep(time.Second * time.Duration(1))
+	}
+	close(ch)
+	wait.Done()
+
+	return
+}
+
+func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+	// We currently have to load configuration from filesystem first in order to obtain Registry Host/Port
+	configuration := &ConfigurationStruct{}
+	err := config.LoadFromFile(useProfile, configuration)
+	if err != nil {
+		return nil, err
+	}
+
+	return configuration, nil
+}
+
+func setLoggingTarget() string {
+	if Configuration.Logging.EnableRemote {
+		return Configuration.Clients["Logging"].Url() + clients.ApiLoggingRoute
+	}
+	return Configuration.Logging.File
+}

--- a/internal/security/fileprovider/interface.go
+++ b/internal/security/fileprovider/interface.go
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+// TokenProvider is the interface that the main program expects
+// for implemeneting token generation
+type TokenProvider interface {
+	// Set configuration
+	SetConfiguration(secretConfig SecretServiceInfo, tokenConfig TokenFileProviderInfo)
+	// Generate tokens
+	Run() error
+}

--- a/internal/security/fileprovider/mocks/mock.go
+++ b/internal/security/fileprovider/mocks/mock.go
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockTokenProvider struct {
+	mock.Mock
+}
+
+// Run see interface.go
+func (p *MockTokenProvider) Run() error {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := p.Called()
+	return arguments.Error(0)
+}
+
+func (p *MockTokenProvider) SetConfiguration(secretConfig SecretServiceInfo, tokenConfig TokenFileProviderInfo) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	p.Called(secretConfig, tokenConfig)
+}

--- a/internal/security/fileprovider/mocks/mock_test.go
+++ b/internal/security/fileprovider/mocks/mock_test.go
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface TokenProvider = &MockTokenProvider{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockRun(t *testing.T) {
+	p := &MockTokenProvider{}
+	p.On("Run").Return(nil)
+
+	err := p.Run()
+
+	assert.Nil(t, err)
+	p.AssertExpectations(t)
+}
+
+func TestMockSetConfiguration(t *testing.T) {
+	p := &MockTokenProvider{}
+	p.On("SetConfiguration", SecretServiceInfo{}, TokenFileProviderInfo{})
+
+	p.SetConfiguration(SecretServiceInfo{}, TokenFileProviderInfo{})
+
+	p.AssertExpectations(t)
+}

--- a/internal/security/fileprovider/provider.go
+++ b/internal/security/fileprovider/provider.go
@@ -1,0 +1,166 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenreader"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/edgex-go/internal/security/tokenconfig"
+	"github.com/edgexfoundry/edgex-go/internal/security/vaultclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// fileTokenProvider stores instance data
+type fileTokenProvider struct {
+	logger            logger.LoggingClient
+	fileOpener        fileioperformer.FileIoPerformer
+	tokenProvider     authtokenreader.AuthTokenReader
+	tokenConfigParser tokenconfig.TokenConfigParser
+	vaultClient       vaultclient.VaultClient
+	snapDetectionFunc func() bool
+	secretConfig      SecretServiceInfo
+	tokenConfig       TokenFileProviderInfo
+}
+
+// NewTokenProvider creates a new TokenProvider
+func NewTokenProvider(logger logger.LoggingClient,
+	fileOpener fileioperformer.FileIoPerformer,
+	tokenProvider authtokenreader.AuthTokenReader,
+	tokenConfigParser tokenconfig.TokenConfigParser,
+	vaultClient vaultclient.VaultClient) TokenProvider {
+	return &fileTokenProvider{
+		logger:            logger,
+		fileOpener:        fileOpener,
+		tokenProvider:     tokenProvider,
+		tokenConfigParser: tokenConfigParser,
+		vaultClient:       vaultClient,
+		snapDetectionFunc: DetectSnapEnvironment,
+	}
+}
+
+// Set configuration
+func (p *fileTokenProvider) SetConfiguration(secretConfig SecretServiceInfo, tokenConfig TokenFileProviderInfo) {
+	p.secretConfig = secretConfig.WithDefaults(p.snapDetectionFunc)
+	p.tokenConfig = tokenConfig.WithDefaults()
+}
+
+// Unit testing hook for detecting a snap environment
+func (p *fileTokenProvider) setSnapDetector(isSnap func() bool) {
+	p.snapDetectionFunc = isSnap
+}
+
+// Do whatever is needed
+func (p *fileTokenProvider) Run() error {
+	p.logger.Info("Generating Vault tokens")
+
+	err := p.tokenProvider.Load(p.tokenConfig.PrivilegedTokenPath)
+	if err != nil {
+		p.logger.Error(fmt.Sprintf("failed to read privileged access token: %s", err.Error()))
+		return err
+	}
+
+	err = p.tokenConfigParser.Load(p.tokenConfig.ConfigFile)
+	if err != nil {
+		p.logger.Error(fmt.Sprintf("failed to read token configuration file %s: %s", p.tokenConfig.ConfigFile, err.Error()))
+		return err
+	}
+
+	serviceList := p.tokenConfigParser.ServiceKeys()
+	for _, serviceName := range serviceList {
+
+		p.logger.Info(fmt.Sprintf("generating policy/token defaults for service %s", serviceName))
+
+		serviceConfig := p.tokenConfigParser.GetServiceConfig(serviceName)
+		servicePolicy := make(map[string]interface{})
+		createTokenParameters := make(map[string]interface{})
+
+		if serviceConfig.UseDefaults {
+			p.logger.Info(fmt.Sprintf("using policy/token defaults for service %s", serviceName))
+			servicePolicy = makeDefaultTokenPolicy(serviceName)
+			createTokenParameters = makeDefaultTokenParameters(serviceName)
+		}
+
+		if serviceConfig.CustomPolicy != nil {
+			customPolicy := serviceConfig.CustomPolicy
+			if customPolicy["path"] != nil {
+				customPaths := customPolicy["path"].(map[string]interface{})
+				if servicePolicy["path"] == nil {
+					servicePolicy["path"] = make(map[string]interface{})
+				}
+				for k, v := range customPaths {
+					(servicePolicy["path"]).(map[string]interface{})[k] = v
+				}
+			}
+		}
+
+		if serviceConfig.CustomTokenParameters != nil {
+			// Custom token parameters override the defaults
+			createTokenParameters = mergeMaps(createTokenParameters, serviceConfig.CustomTokenParameters)
+		}
+
+		// Set a meta property that consuming serices can use to automatically scope secret queries
+		meta := make(map[string]interface{})
+		meta["edgex-service-name"] = serviceName
+		createTokenParameters["meta"] = meta
+
+		// Always create a policy with this name
+		policyName := "edgex-service-" + serviceName
+
+		policyBytes, err := json.Marshal(servicePolicy)
+		if err != nil {
+			p.logger.Error(fmt.Sprintf("failed encode service policy for %s: %s", serviceName, err.Error()))
+			return err
+		}
+
+		code, err := p.vaultClient.InstallPolicy(p.tokenProvider, policyName, string(policyBytes))
+		if code != http.StatusNoContent {
+			p.logger.Error(fmt.Sprintf("failed to install policy %s: %d", policyName, code))
+			return err
+		}
+
+		var createTokenResponse interface{}
+		code, err = p.vaultClient.CreateToken(p.tokenProvider, createTokenParameters, &createTokenResponse)
+		if code != http.StatusOK {
+			p.logger.Error(fmt.Sprintf("failed to create vault token for service %s: %d", serviceName, code))
+			return err
+		}
+
+		outputTokenDir := filepath.Join(p.tokenConfig.OutputDir, serviceName)
+		outputTokenFilename := filepath.Join(outputTokenDir, p.tokenConfig.OutputFilename)
+		err = p.fileOpener.MkdirAll(outputTokenDir, os.FileMode(0700))
+		if err != nil {
+			p.logger.Error(fmt.Sprintf("failed to create base directory path(s) %s: %s", outputTokenDir, err.Error()))
+			return err
+		}
+		writeCloser, err := p.fileOpener.OpenFileWriter(outputTokenFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600))
+		if err != nil {
+			p.logger.Error(fmt.Sprintf("failed open token file for writing %s: %s", outputTokenFilename, err.Error()))
+			return err
+		}
+		defer writeCloser.Close()
+
+		json.NewEncoder(writeCloser).Encode(createTokenResponse) // Write resulting token
+	}
+
+	return nil
+}

--- a/internal/security/fileprovider/provider_test.go
+++ b/internal/security/fileprovider/provider_test.go
@@ -1,0 +1,368 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package fileprovider
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/authtokenreader/mocks"
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileioperformer/mocks"
+	"github.com/edgexfoundry/edgex-go/internal/security/tokenconfig"
+	. "github.com/edgexfoundry/edgex-go/internal/security/tokenconfig/mocks"
+	. "github.com/edgexfoundry/edgex-go/internal/security/vaultclient/mocks"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+/*
+Test cases:
+
+1. Create multiple service tokens with no defaults
+2. Create a service with no defaults and custom policy
+3. Create a service with no defaults and custom token parameters
+4. Create a service with defaults for policy and token parameters
+*/
+
+// TestMultipleTokensWithNoDefaults
+func TestMultipleTokensWithNoDefaults(t *testing.T) {
+	// Arrange
+	privilegedTokenPath := "/dummy/privileged/token.json"
+	configFile := "token-config.json"
+	outputDir := "/outputdir"
+	outputFilename := "secrets-token.json"
+
+	mockLogger := logger.MockLogger{}
+
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	expectedService1Dir := filepath.Join(outputDir, "service1")
+	expectedService1File := filepath.Join(expectedService1Dir, outputFilename)
+	service1Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService1Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService1File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service1Buffer}, nil)
+	expectedService2Dir := filepath.Join(outputDir, "service2")
+	expectedService2File := filepath.Join(expectedService2Dir, outputFilename)
+	service2Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService2Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService2File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service2Buffer}, nil)
+
+	mockAuthTokenReader := &MockAuthTokenReader{}
+	mockAuthTokenReader.On("Load", privilegedTokenPath).Return(nil)
+
+	mockTokenConfigParser := &MockTokenConfigParser{}
+	mockTokenConfigParser.On("Load", configFile).Return(nil)
+	mockTokenConfigParser.On("ServiceKeys").Return([]string{"service1", "service2"})
+	mockTokenConfigParser.On("GetServiceConfig", "service1").Return(tokenconfig.ServiceKey{})
+	mockTokenConfigParser.On("GetServiceConfig", "service2").Return(tokenconfig.ServiceKey{})
+
+	expectedService1Policy := "{}"
+	expectedService2Policy := "{}"
+	expectedService1Parameters := makeMetaServiceName("service1")
+	expectedService2Parameters := makeMetaServiceName("service2")
+	mockVaultClient := &MockVaultClient{}
+	mockVaultClient.On("InstallPolicy", mock.Anything, "edgex-service-service1", expectedService1Policy).Return(http.StatusNoContent, nil)
+	mockVaultClient.On("InstallPolicy", mock.Anything, "edgex-service-service2", expectedService2Policy).Return(http.StatusNoContent, nil)
+	mockVaultClient.On("CreateToken", mock.Anything, expectedService1Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("service1", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+	mockVaultClient.On("CreateToken", mock.Anything, expectedService2Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("service2", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenReader, mockTokenConfigParser, mockVaultClient)
+	p.(*fileTokenProvider).setSnapDetector(func() bool { return false })
+	p.SetConfiguration(SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: privilegedTokenPath,
+		ConfigFile:          configFile,
+		OutputDir:           outputDir,
+		OutputFilename:      outputFilename,
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	// - {OutputDir}/service1/{OutputFilename} w/proper contents
+	// - {OutputDir}/service2/{OutputFilename} w/proper contents
+	// - Correct policy for service1
+	// - Correct policy for service2
+	// - All other expectations met
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenReader.AssertExpectations(t)
+	mockTokenConfigParser.AssertExpectations(t)
+	mockVaultClient.AssertExpectations(t)
+	assert.Equal(t, expectedTokenFile("service1"), service1Buffer.Bytes())
+	assert.Equal(t, expectedTokenFile("service2"), service2Buffer.Bytes())
+}
+
+func setCreateTokenResponse(serviceName string, retval *interface{}) {
+	t := make(map[string]interface{})
+	t["request_id"] = "f00341c1-fad5-f6e6-13fd-235617f858a1"
+	t["auth"] = make(map[string]interface{})
+	t["auth"].(map[string]interface{})["client_token"] = "s.wOrq9dO9kzOcuvB06CMviJhZ"
+	t["auth"].(map[string]interface{})["accessor"] = "B6oixijqmeR4bsLOJH88Ska9"
+	(*retval) = t
+}
+
+func makeMetaServiceName(serviceName string) map[string]interface{} {
+	createTokenParameters := make(map[string]interface{})
+	meta := make(map[string]interface{})
+	meta["edgex-service-name"] = serviceName
+	createTokenParameters["meta"] = meta
+	return createTokenParameters
+}
+
+func expectedTokenFile(serviceName string) []byte {
+	var tokenResponse interface{}
+	setCreateTokenResponse(serviceName, &tokenResponse)
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(tokenResponse)
+	// Debugging note: take care to not write out the buffer or it will disturb the read pointer
+	return b.Bytes()
+}
+
+// TestNoDefaultsCustomPolicy
+func TestNoDefaultsCustomPolicy(t *testing.T) {
+	// Arrange
+	privilegedTokenPath := "/dummy/privileged/token.json"
+	configFile := "token-config.json"
+	outputDir := "/outputdir"
+	outputFilename := "secrets-token.json"
+
+	mockLogger := logger.MockLogger{}
+
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	expectedService1Dir := filepath.Join(outputDir, "myservice")
+	expectedService1File := filepath.Join(expectedService1Dir, outputFilename)
+	service1Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService1Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService1File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service1Buffer}, nil)
+
+	mockAuthTokenReader := &MockAuthTokenReader{}
+	mockAuthTokenReader.On("Load", privilegedTokenPath).Return(nil)
+
+	mockTokenConfigParser := &MockTokenConfigParser{}
+	mockTokenConfigParser.On("Load", configFile).Return(nil)
+	mockTokenConfigParser.On("ServiceKeys").Return([]string{"myservice"})
+	mockTokenConfigParser.On("GetServiceConfig", "myservice").Return(tokenconfig.ServiceKey{
+		CustomPolicy: makeCustomTokenPolicy(),
+	})
+
+	expectedService1Policy := `{"path":{"secret/non/standard/location/*":{"capabilities":["list","read"]}}}`
+	expectedService1Parameters := makeMetaServiceName("myservice")
+	mockVaultClient := &MockVaultClient{}
+	mockVaultClient.On("InstallPolicy", mock.Anything, "edgex-service-myservice", expectedService1Policy).Return(http.StatusNoContent, nil)
+	mockVaultClient.On("CreateToken", mock.Anything, expectedService1Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("myservice", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenReader, mockTokenConfigParser, mockVaultClient)
+	p.(*fileTokenProvider).setSnapDetector(func() bool { return false })
+	p.SetConfiguration(SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: privilegedTokenPath,
+		ConfigFile:          configFile,
+		OutputDir:           outputDir,
+		OutputFilename:      outputFilename,
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	// - {OutputDir}/myservice/{OutputFilename} w/proper contents
+	// - Correct policy for myservice
+	// - All other expectations met
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenReader.AssertExpectations(t)
+	mockTokenConfigParser.AssertExpectations(t)
+	mockVaultClient.AssertExpectations(t)
+	assert.Equal(t, expectedTokenFile("myservice"), service1Buffer.Bytes())
+}
+
+func makeCustomTokenPolicy() map[string]interface{} {
+	entry := struct {
+		Path interface{} `json:"path"`
+	}{
+		Path: map[string]interface{}{"secret/non/standard/location/*": struct {
+			Capabilities []string `json:"capabilities"`
+		}{
+			Capabilities: []string{"list", "read"},
+		}},
+	}
+
+	// Marshal the data and then unmarshal it again to turn it into an opaque data structure
+
+	bytes, _ := json.Marshal(entry)
+
+	retval := make(map[string]interface{})
+	json.Unmarshal(bytes, &retval)
+	return retval
+}
+
+// TestNoDefaultsCustomTokenParameters
+func TestNoDefaultsCustomTokenParameters(t *testing.T) {
+	// Arrange
+	privilegedTokenPath := "/dummy/privileged/token.json"
+	configFile := "token-config.json"
+	outputDir := "/outputdir"
+	outputFilename := "secrets-token.json"
+
+	mockLogger := logger.MockLogger{}
+
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	expectedService1Dir := filepath.Join(outputDir, "myservice")
+	expectedService1File := filepath.Join(expectedService1Dir, outputFilename)
+	service1Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService1Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService1File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service1Buffer}, nil)
+
+	mockAuthTokenReader := &MockAuthTokenReader{}
+	mockAuthTokenReader.On("Load", privilegedTokenPath).Return(nil)
+
+	mockTokenConfigParser := &MockTokenConfigParser{}
+	mockTokenConfigParser.On("Load", configFile).Return(nil)
+	mockTokenConfigParser.On("ServiceKeys").Return([]string{"myservice"})
+	mockTokenConfigParser.On("GetServiceConfig", "myservice").Return(tokenconfig.ServiceKey{
+		CustomTokenParameters: makeCustomTokenParameters(),
+	})
+
+	expectedService1Policy := "{}"
+	expectedService1Parameters := makeCustomTokenParameters()
+	expectedService1Parameters["meta"] = makeMetaServiceName("myservice")["meta"]
+	mockVaultClient := &MockVaultClient{}
+	mockVaultClient.On("InstallPolicy", mock.Anything, "edgex-service-myservice", expectedService1Policy).Return(http.StatusNoContent, nil)
+	mockVaultClient.On("CreateToken", mock.Anything, expectedService1Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("myservice", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenReader, mockTokenConfigParser, mockVaultClient)
+	p.(*fileTokenProvider).setSnapDetector(func() bool { return false })
+	p.SetConfiguration(SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: privilegedTokenPath,
+		ConfigFile:          configFile,
+		OutputDir:           outputDir,
+		OutputFilename:      outputFilename,
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	// - {OutputDir}/myservice/{OutputFilename} w/proper contents
+	// - Correct token parameters for myservice
+	// - All other expectations met
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenReader.AssertExpectations(t)
+	mockTokenConfigParser.AssertExpectations(t)
+	mockVaultClient.AssertExpectations(t)
+	assert.Equal(t, expectedTokenFile("myservice"), service1Buffer.Bytes())
+}
+
+func makeCustomTokenParameters() map[string]interface{} {
+	retval := make(map[string]interface{})
+	retval["key1"] = "value1"
+	return retval
+}
+
+// TestTokenUsingDefaults
+func TestTokenUsingDefaults(t *testing.T) {
+	// Arrange
+	privilegedTokenPath := "/dummy/privileged/token.json"
+	configFile := "token-config.json"
+	outputDir := "/outputdir"
+	outputFilename := "secrets-token.json"
+
+	mockLogger := logger.MockLogger{}
+
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	expectedService1Dir := filepath.Join(outputDir, "myservice")
+	expectedService1File := filepath.Join(expectedService1Dir, outputFilename)
+	service1Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService1Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService1File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service1Buffer}, nil)
+
+	mockAuthTokenReader := &MockAuthTokenReader{}
+	mockAuthTokenReader.On("Load", privilegedTokenPath).Return(nil)
+
+	mockTokenConfigParser := &MockTokenConfigParser{}
+	mockTokenConfigParser.On("Load", configFile).Return(nil)
+	mockTokenConfigParser.On("ServiceKeys").Return([]string{"myservice"})
+	mockTokenConfigParser.On("GetServiceConfig", "myservice").Return(tokenconfig.ServiceKey{
+		UseDefaults: true,
+	})
+
+	expectedService1Policy := `{"path":{"secret/edgex/myservice/*":{"capabilities":["create","update","delete","list","read"]}}}`
+	expectedService1Parameters := makeDefaultTokenParameters("myservice")
+	expectedService1Parameters["meta"] = makeMetaServiceName("myservice")["meta"]
+	mockVaultClient := &MockVaultClient{}
+	mockVaultClient.On("InstallPolicy", mock.Anything, "edgex-service-myservice", expectedService1Policy).Return(http.StatusNoContent, nil)
+	mockVaultClient.On("CreateToken", mock.Anything, expectedService1Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("myservice", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenReader, mockTokenConfigParser, mockVaultClient)
+	p.(*fileTokenProvider).setSnapDetector(func() bool { return false })
+	p.SetConfiguration(SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: privilegedTokenPath,
+		ConfigFile:          configFile,
+		OutputDir:           outputDir,
+		OutputFilename:      outputFilename,
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	// - {OutputDir}/myservice/{OutputFilename} w/proper contents
+	// - Correct token parameters for myservice
+	// - All other expectations met
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenReader.AssertExpectations(t)
+	mockTokenConfigParser.AssertExpectations(t)
+	mockVaultClient.AssertExpectations(t)
+	assert.Equal(t, expectedTokenFile("myservice"), service1Buffer.Bytes())
+}
+
+//
+// mocks
+//
+
+type writeCloserBuffer struct {
+	*bytes.Buffer
+}
+
+func (wcb *writeCloserBuffer) Close() error {
+	return nil
+}

--- a/internal/security/fileprovider/res/edgex-privileged-token-creator.hcl
+++ b/internal/security/fileprovider/res/edgex-privileged-token-creator.hcl
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+//
+// This file is taken from
+// https://raw.githubusercontent.com/edgexfoundry/edgex-docs/master/security/token-file-provider.1.rst
+//
+// This is a reference copy of the policy that security-file-token-provider requires
+// in order to run and create policies for other services.
+//
+
+path "auth/token/create" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "auth/token/create-orphan" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "auth/token/create/*" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "sys/policies/acl/edgex-service-*"
+{
+  capabilities = ["create", "read", "update", "delete" ]
+}
+
+path "sys/policies/acl"
+{
+  capabilities = ["list"]
+}

--- a/internal/security/fileprovider/types.go
+++ b/internal/security/fileprovider/types.go
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"os"
+)
+
+type SecretServiceInfo struct {
+	// URL scheme
+	Scheme string
+	// Host name for the Vault server (default: localhost if SNAP_NAME defined, else edgex-vault)
+	Server string
+	// Port number of the Vault server (default: 8200)
+	Port int
+	// Path to CA cert
+	CaFilePath string
+}
+
+type TokenFileProviderInfo struct {
+	// Path to Vault authorization token to be used by the service (default: /run/edgex/secrets/token-file-provider/secrets-token.json)
+	PrivilegedTokenPath string
+	// Configuration file used to control token creation (default: res/token-config.json)
+	ConfigFile string
+	// Base directory for token file output (default: /run/edgex/secrets)
+	OutputDir string
+	// File name for token file (default: secrets-token.json)
+	OutputFilename string
+}
+
+func setStringDefault(s *string, dflt string) {
+	if *s == "" {
+		*s = dflt
+	}
+}
+
+func setIntDefault(i *int, dflt int) {
+	if *i == 0 {
+		*i = dflt
+	}
+}
+
+func DetectSnapEnvironment() bool {
+	return os.Getenv(SnapNameEnvVar) != ""
+}
+
+func (info SecretServiceInfo) WithDefaults(isSnap func() bool) SecretServiceInfo {
+	if isSnap() {
+		setStringDefault(&info.Server, DefaultVaultServerSnap)
+	} else {
+		setStringDefault(&info.Server, DefaultVaultServer)
+	}
+	setIntDefault(&info.Port, DefaultVaultPort)
+	return info
+}
+
+func (info TokenFileProviderInfo) WithDefaults() TokenFileProviderInfo {
+	setStringDefault(&info.PrivilegedTokenPath, DefaultPrivilegedTokenPath)
+	setStringDefault(&info.ConfigFile, DefaultConfigFile)
+	setStringDefault(&info.OutputDir, DefaultOutputDir)
+	setStringDefault(&info.OutputFilename, DefaultOutputFilename)
+	return info
+}

--- a/internal/security/fileprovider/types_test.go
+++ b/internal/security/fileprovider/types_test.go
@@ -1,0 +1,114 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package fileprovider
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectSnapEnvironment(t *testing.T) {
+	// Arrange
+	inSnap := os.Getenv(SnapNameEnvVar) != ""
+
+	// Act
+	snap := DetectSnapEnvironment()
+
+	// Assert
+	assert.Equal(t, inSnap, snap)
+}
+
+func TestDefaultVaultServerNoSnap(t *testing.T) {
+	// Arrange
+	i := SecretServiceInfo{}
+	noSnap := func() bool { return false }
+
+	// Act
+	i2 := i.WithDefaults(noSnap)
+
+	// Assert
+	assert.Equal(t, DefaultVaultServer, i2.Server)
+}
+
+func TestDefaultVaultServerSnap(t *testing.T) {
+	// Arrange
+	i := SecretServiceInfo{}
+	snap := func() bool { return true }
+
+	// Act
+	i2 := i.WithDefaults(snap)
+
+	// Assert
+	assert.Equal(t, DefaultVaultServerSnap, i2.Server)
+}
+
+func TestDefaultVaultPort(t *testing.T) {
+	// Arrange
+	i := SecretServiceInfo{}
+	snap := func() bool { return true }
+
+	// Act
+	i2 := i.WithDefaults(snap)
+
+	// Assert
+	assert.Equal(t, DefaultVaultPort, i2.Port)
+}
+
+func TestDefaultPrivilegedTokenPath(t *testing.T) {
+	// Arrange
+	i := TokenFileProviderInfo{}
+
+	// Act
+	i2 := i.WithDefaults()
+
+	// Assert
+	assert.Equal(t, DefaultPrivilegedTokenPath, i2.PrivilegedTokenPath)
+}
+
+func TestDefaultConfigFile(t *testing.T) {
+	// Arrange
+	i := TokenFileProviderInfo{}
+
+	// Act
+	i2 := i.WithDefaults()
+
+	// Assert
+	assert.Equal(t, DefaultConfigFile, i2.ConfigFile)
+}
+
+func TestDefaultOutputDir(t *testing.T) {
+	// Arrange
+	i := TokenFileProviderInfo{}
+
+	// Act
+	i2 := i.WithDefaults()
+
+	// Assert
+	assert.Equal(t, DefaultOutputDir, i2.OutputDir)
+}
+
+func TestDefaultOutputFilename(t *testing.T) {
+	// Arrange
+	i := TokenFileProviderInfo{}
+
+	// Act
+	i2 := i.WithDefaults()
+
+	// Assert
+	assert.Equal(t, DefaultOutputFilename, i2.OutputFilename)
+}

--- a/internal/security/fileprovider/util.go
+++ b/internal/security/fileprovider/util.go
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+func mergeMaps(defaults map[string]interface{}, other map[string]interface{}) map[string]interface{} {
+	// Defaults are overridden
+	for key, value := range other {
+		defaults[key] = value
+	}
+	return defaults
+}

--- a/internal/security/fileprovider/util_test.go
+++ b/internal/security/fileprovider/util_test.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package fileprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeMaps(t *testing.T) {
+	// Arrange
+	defaults := map[string]interface{}{"notoverridden": true, "overridden": false}
+	other := map[string]interface{}{"overridden": true, "newkey": true}
+
+	// Act
+	merged := mergeMaps(defaults, other)
+
+	// Assert
+	assert.True(t, merged["notoverridden"].(bool))
+	assert.True(t, merged["overridden"].(bool))
+	assert.True(t, merged["newkey"].(bool))
+}

--- a/internal/security/tokenconfig/interface.go
+++ b/internal/security/tokenconfig/interface.go
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package tokenconfig
+
+// TokenConfigParser returns authorization token for secret store
+type TokenConfigParser interface {
+	// Load loads authorization token
+	Load(path string) error
+	// Get service keys
+	ServiceKeys() []string
+	// Get configuration for a service
+	GetServiceConfig(serviceName string) ServiceKey
+}

--- a/internal/security/tokenconfig/methods.go
+++ b/internal/security/tokenconfig/methods.go
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package tokenconfig
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+)
+
+type tokenConfigParser struct {
+	fileOpener fileioperformer.FileIoPerformer
+	tokenConf  TokenConfFile
+}
+
+// NewTokenConfigParser creates a new TokenConfigParser
+func NewTokenConfigParser(opener fileioperformer.FileIoPerformer) TokenConfigParser {
+	return &tokenConfigParser{fileOpener: opener}
+}
+
+func (p *tokenConfigParser) Load(path string) error {
+	reader, err := p.fileOpener.OpenFileReader(path, os.O_RDONLY, 0400)
+	if err != nil {
+		return err
+	}
+	readCloser := fileioperformer.MakeReadCloser(reader)
+	fileContents, err := ioutil.ReadAll(readCloser)
+	if err != nil {
+		return err
+	}
+	defer readCloser.Close()
+
+	var parsedContents TokenConfFile
+	err = json.Unmarshal(fileContents, &parsedContents)
+	if err != nil {
+		return err
+	}
+
+	p.tokenConf = parsedContents
+	return nil
+}
+
+func (p *tokenConfigParser) ServiceKeys() []string {
+	serviceNames := make([]string, 0, len(p.tokenConf))
+	for serviceName := range p.tokenConf {
+		serviceNames = append(serviceNames, serviceName)
+	}
+	return serviceNames
+}
+
+func (p tokenConfigParser) GetServiceConfig(service string) ServiceKey {
+	return p.tokenConf[service]
+}

--- a/internal/security/tokenconfig/methods_test.go
+++ b/internal/security/tokenconfig/methods_test.go
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package tokenconfig
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileioperformer/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sampleJSON = `{
+	"service-name": {
+	  "edgex_use_defaults": true,
+	  "custom_policy": {
+		"path": {
+		  "secret/non/standard/location/*": {
+		    "capabilities": [ "list", "read" ]
+		  }
+		}
+	  },
+	  "custom_token_parameters": { "custom_option": "custom_vaule" }
+	}
+  }`
+
+func TestTokenConfigParser(t *testing.T) {
+	stringReader := strings.NewReader(sampleJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewTokenConfigParser(mockFileIoPerformer)
+
+	err := p.Load("/dev/null")
+	assert.Nil(t, err)
+
+	serviceKeys := p.ServiceKeys()
+	assert.Equal(t, []string{"service-name"}, serviceKeys)
+
+	aService := p.GetServiceConfig("service-name")
+
+	assert.Equal(t, true, aService.UseDefaults)
+	assert.Contains(t, aService.CustomPolicy, "path")
+	var path = aService.CustomPolicy["path"].(map[string]interface{})
+	assert.Contains(t, path, "secret/non/standard/location/*")
+	// Don't need to go further down the type assertion rabbit hole to prove that this is working
+	assert.Contains(t, aService.CustomTokenParameters, "custom_option")
+}

--- a/internal/security/tokenconfig/mocks/mock.go
+++ b/internal/security/tokenconfig/mocks/mock.go
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	. "github.com/edgexfoundry/edgex-go/internal/security/tokenconfig"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockTokenConfigParser struct {
+	mock.Mock
+}
+
+func (m *MockTokenConfigParser) Load(path string) error {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(path)
+	return arguments.Error(0)
+}
+
+func (m *MockTokenConfigParser) ServiceKeys() []string {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called()
+	return arguments.Get(0).([]string)
+}
+
+func (m *MockTokenConfigParser) GetServiceConfig(service string) ServiceKey {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(service)
+	return arguments.Get(0).(ServiceKey)
+}

--- a/internal/security/tokenconfig/mocks/mock_test.go
+++ b/internal/security/tokenconfig/mocks/mock_test.go
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/tokenconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface TokenConfigParser = &MockTokenConfigParser{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockLoad(t *testing.T) {
+	parser := &MockTokenConfigParser{}
+	parser.On("Load", "path").Return(nil)
+
+	err := parser.Load("path")
+
+	assert.Nil(t, err)
+	parser.AssertExpectations(t)
+}
+
+func TestMockServiceKeys(t *testing.T) {
+	parser := &MockTokenConfigParser{}
+	parser.On("ServiceKeys").Return([]string{"key1"})
+
+	keys := parser.ServiceKeys()
+
+	assert.Equal(t, "key1", keys[0])
+	parser.AssertExpectations(t)
+}
+
+func TestMockGetServiceConfig(t *testing.T) {
+	parser := &MockTokenConfigParser{}
+	parser.On("GetServiceConfig", "key1").Return(ServiceKey{UseDefaults: true})
+
+	sk := parser.GetServiceConfig("key1")
+
+	assert.True(t, sk.UseDefaults)
+	parser.AssertExpectations(t)
+}

--- a/internal/security/tokenconfig/types.go
+++ b/internal/security/tokenconfig/types.go
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package tokenconfig
+
+/*
+
+Example config file
+
+{
+  "service-name": {
+    "edgex_use_defaults": true,
+    "custom_policy": [
+      {
+        "path": {
+          "secret/non/standard/location/*": {
+            "capabilities": [ "list", "read" ]
+          }
+        }
+      }
+    ],
+    "custom_token_parameters": { }
+  }
+}
+
+*/
+type TokenConfFile map[string]ServiceKey
+
+type ServiceKey struct {
+	UseDefaults           bool                   `json:"edgex_use_defaults"` // BUG - change to underscores in man page
+	CustomPolicy          map[string]interface{} `json:"custom_policy"`      // JSON serialization of HCL
+	CustomTokenParameters map[string]interface{} `json:"custom_token_parameters"`
+}
+
+/* Note that above types must be exported in order to visible to JSON marshaller */

--- a/internal/security/vaultclient/const.go
+++ b/internal/security/vaultclient/const.go
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author: Tingyu Zeng, Dell
+ * @version: 1.1.0
+ *******************************************************************************/
+package vaultclient
+
+const (
+	VaultToken       = "X-Vault-Token"
+	VaultHealthAPI   = "/v1/sys/health"
+	VaultInitAPI     = "/v1/sys/init"
+	VaultUnsealAPI   = "/v1/sys/unseal"
+	JsonContentType  = "application/json"
+	CreatePolicyPath = "/v1/sys/policies/acl/%s"
+	CreateTokenAPI   = "/v1/auth/token/create"
+)

--- a/internal/security/vaultclient/interface.go
+++ b/internal/security/vaultclient/interface.go
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package vaultclient
+
+import (
+	"io"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenreader"
+)
+
+// VaultClient is interface to Vault
+type VaultClient interface {
+	HealthCheck() (statusCode int, err error)
+	Init(config SecretServiceInfo, vmkWriter io.Writer) (statusCode int, err error)
+	Unseal(config SecretServiceInfo, vmkReader io.Reader) (statusCode int, err error)
+	InstallPolicy(token authtokenreader.AuthTokenReader,
+		policyName string, policyDocument string) (statusCode int, err error)
+	CreateToken(token authtokenreader.AuthTokenReader,
+		parameters map[string]interface{}, response interface{}) (statusCode int, err error)
+}

--- a/internal/security/vaultclient/mocks/mock.go
+++ b/internal/security/vaultclient/mocks/mock.go
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"io"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenreader"
+	. "github.com/edgexfoundry/edgex-go/internal/security/vaultclient"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockVaultClient struct {
+	mock.Mock
+}
+
+func (m *MockVaultClient) HealthCheck() (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called()
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockVaultClient) Init(config SecretServiceInfo, vmkWriter io.Writer) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(config, vmkWriter)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockVaultClient) Unseal(config SecretServiceInfo, vmkReader io.Reader) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(config, vmkReader)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockVaultClient) InstallPolicy(token authtokenreader.AuthTokenReader, policyName string, policyDocument string) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(token, policyName, policyDocument)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockVaultClient) CreateToken(token authtokenreader.AuthTokenReader, parameters map[string]interface{}, response interface{}) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(token, parameters, response)
+	return arguments.Int(0), arguments.Error(1)
+}

--- a/internal/security/vaultclient/mocks/mock_test.go
+++ b/internal/security/vaultclient/mocks/mock_test.go
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenreader"
+	. "github.com/edgexfoundry/edgex-go/internal/security/vaultclient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface VaultClient = &MockVaultClient{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockHealthCheck(t *testing.T) {
+	mockClient := &MockVaultClient{}
+	mockClient.On("HealthCheck").Return(http.StatusOK, nil)
+
+	rc, err := mockClient.HealthCheck()
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockInit(t *testing.T) {
+	config := SecretServiceInfo{}
+	scratchBuffer := new(bytes.Buffer)
+	mockClient := &MockVaultClient{}
+	mockClient.On("Init", config, scratchBuffer).Return(http.StatusOK, nil)
+
+	rc, err := mockClient.Init(config, scratchBuffer)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockUnseal(t *testing.T) {
+	config := SecretServiceInfo{}
+	scratchBuffer := new(bytes.Buffer)
+	mockClient := &MockVaultClient{}
+	mockClient.On("Unseal", config, scratchBuffer).Return(http.StatusOK, nil)
+
+	rc, err := mockClient.Unseal(config, scratchBuffer)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockInstallPolicy(t *testing.T) {
+	mockClient := &MockVaultClient{}
+	mockClient.On("InstallPolicy", (authtokenreader.AuthTokenReader)(nil), "foo", "bar").Return(http.StatusOK, nil)
+
+	rc, err := mockClient.InstallPolicy((authtokenreader.AuthTokenReader)(nil), "foo", "bar")
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockCreateToken(t *testing.T) {
+	params := make(map[string]interface{})
+	response := make(map[string]interface{})
+	mockClient := &MockVaultClient{}
+	mockClient.On("CreateToken", (authtokenreader.AuthTokenReader)(nil), params, response).Return(http.StatusOK, nil)
+
+	rc, err := mockClient.CreateToken((authtokenreader.AuthTokenReader)(nil), params, response)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}

--- a/internal/security/vaultclient/requestor.go
+++ b/internal/security/vaultclient/requestor.go
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author: Tingyu Zeng, Dell
+ * @version: 1.1.0
+ *******************************************************************************/
+package vaultclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+type Requestor interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type FluentRequestor interface {
+	Insecure() Requestor
+	WithCaCert(io.Reader) Requestor
+}
+
+type fluentRequestor struct {
+	logger logger.LoggingClient
+}
+
+func NewRequestor(logger logger.LoggingClient) FluentRequestor {
+	return &fluentRequestor{logger}
+}
+
+func (r *fluentRequestor) Insecure() Requestor {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return &http.Client{Timeout: 10 * time.Second, Transport: tr}
+}
+
+func (r *fluentRequestor) WithCaCert(caReader io.Reader) Requestor {
+	readCloser := fileioperformer.MakeReadCloser(caReader)
+	caCert, err := ioutil.ReadAll(readCloser)
+	defer readCloser.Close()
+	if err != nil {
+		r.logger.Error("failed to load rootCA certificate.")
+		return nil
+	}
+	r.logger.Info("successful loading the rootCA certificate.")
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:            caCertPool,
+			InsecureSkipVerify: false,
+		},
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	return &http.Client{Timeout: 10 * time.Second, Transport: tr}
+}

--- a/internal/security/vaultclient/testdata/.gitignore
+++ b/internal/security/vaultclient/testdata/.gitignore
@@ -1,0 +1,1 @@
+test-resp-init.json

--- a/internal/security/vaultclient/types.go
+++ b/internal/security/vaultclient/types.go
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package vaultclient
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type SecretServiceInfo struct {
+	Scheme               string
+	Server               string
+	Port                 int
+	CertPath             string
+	CaFilePath           string
+	CertFilePath         string
+	KeyFilePath          string
+	TokenFolderPath      string
+	TokenFile            string
+	VaultSecretShares    int
+	VaultSecretThreshold int
+}
+
+func (s SecretServiceInfo) GetSecretSvcBaseURL() string {
+	url := &url.URL{
+		Scheme: s.Scheme,
+		Host:   fmt.Sprintf("%s:%v", s.Server, s.Port),
+		Path:   "/",
+	}
+	return url.String()
+}

--- a/internal/security/vaultclient/vault.go
+++ b/internal/security/vaultclient/vault.go
@@ -1,0 +1,300 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author: Tingyu Zeng, Dell / Alain Pulluelo, ForgeRock AS
+ * @version: 1.1.0
+ *******************************************************************************/
+
+package vaultclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenreader"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// InitRequest contains a Vault init request regarding the Shamir Secret Sharing (SSS) parameters
+type InitRequest struct {
+	SecretShares    int `json:"secret_shares"`
+	SecretThreshold int `json:"secret_threshold"`
+}
+
+// InitResponse contains a Vault init response
+type InitResponse struct {
+	Keys       []string `json:"keys"`
+	KeysBase64 []string `json:"keys_base64"`
+	RootToken  string   `json:"root_token"`
+}
+
+// UnsealRequest contains a Vault unseal request
+type UnsealRequest struct {
+	Key   string `json:"key"`
+	Reset bool   `json:"reset"`
+}
+
+// UnsealResponse contains a Vault unseal response
+type UnsealResponse struct {
+	Sealed   bool `json:"sealed"`
+	T        int  `json:"t"`
+	N        int  `json:"n"`
+	Progress int  `json:"progress"`
+}
+
+// UpdateAclPolicyRequest contains a ACL policy create/update request
+type UpdateAclPolicyRequest struct {
+	Policy string `json:"policy"`
+}
+
+type vaultClient struct {
+	logger logger.LoggingClient
+	client Requestor
+	scheme string
+	host   string
+}
+
+func NewVaultClient(logger logger.LoggingClient, r Requestor, s string, h string) VaultClient {
+	return &vaultClient{
+		logger: logger,
+		client: r,
+		scheme: s,
+		host:   h,
+	}
+}
+
+func (vc *vaultClient) HealthCheck() (statusCode int, err error) {
+	url := &url.URL{
+		Scheme: vc.scheme,
+		Host:   vc.host,
+		Path:   VaultHealthAPI,
+	}
+	jsonBlock := []byte(`{}`)
+	req, err := http.NewRequest(http.MethodGet, url.String(), bytes.NewBuffer(jsonBlock))
+	req.Header.Set("Content-Type", JsonContentType)
+	resp, err := vc.client.Do(req)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed on checking status of secret store: %s", err.Error()))
+		return 0, err
+	}
+	defer resp.Body.Close()
+	vc.logger.Info(fmt.Sprintf("vault health check HTTP status: %s (StatusCode: %d)", resp.Status, resp.StatusCode))
+	return resp.StatusCode, nil
+}
+
+func (vc *vaultClient) Init(config SecretServiceInfo, vmkWriter io.Writer) (statusCode int, err error) {
+	initRequest := InitRequest{
+		SecretShares:    config.VaultSecretShares,
+		SecretThreshold: config.VaultSecretThreshold,
+	}
+
+	vc.logger.Info(fmt.Sprintf("vault init strategy (SSS parameters): shares=%d threshold=%d", initRequest.SecretShares, initRequest.SecretThreshold))
+	url := &url.URL{
+		Scheme: vc.scheme,
+		Host:   vc.host,
+		Path:   VaultInitAPI,
+	}
+	jsonBlock, err := json.Marshal(&initRequest)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to build the Vault init request (SSS parameters): %s", err.Error()))
+		return 0, err
+	}
+	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewBuffer(jsonBlock))
+	req.Header.Set("Content-Type", JsonContentType)
+	resp, err := vc.client.Do(req)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to send Vault init request: %s", err.Error()))
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		vc.logger.Error(fmt.Sprintf("vault init request failed with status: %s", resp.Status))
+		return resp.StatusCode, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to fetch the Vault init request response body: %s", err.Error()))
+		return 0, err
+	}
+
+	initResp := InitResponse{}
+	if err = json.Unmarshal(body, &initResp); err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to build the JSON structure from the init request response body: %s", err.Error()))
+		return 0, err
+	}
+
+	_, err = vmkWriter.Write(body)
+
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to create Vault init response %s file, HTTP status: %s", config.TokenFolderPath+"/"+config.TokenFile, err.Error()))
+		return 0, err
+	}
+
+	vc.logger.Info("Vault initialization complete.")
+	return resp.StatusCode, nil
+}
+
+func (vc *vaultClient) Unseal(config SecretServiceInfo, vmkReader io.Reader) (statusCode int, err error) {
+	vc.logger.Info(fmt.Sprintf("Vault unsealing Process. Applying key shares."))
+	initResp := InitResponse{}
+	//rawBytes, err := ioutil.ReadFile(filepath.Join(config.TokenFolderPath, config.TokenFile))
+	readCloser := fileioperformer.MakeReadCloser(vmkReader)
+	rawBytes, err := ioutil.ReadAll(readCloser)
+	defer readCloser.Close()
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to read the Vault JSON response init file: %s", err.Error()))
+		return 0, err
+	}
+
+	if err = json.Unmarshal(rawBytes, &initResp); err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to build the JSON structure from the init response body: %s", err.Error()))
+		return 0, err
+	}
+
+	url := &url.URL{
+		Scheme: vc.scheme,
+		Host:   vc.host,
+		Path:   VaultUnsealAPI,
+	}
+
+	keyCounter := 1
+	for _, key := range initResp.KeysBase64 {
+		unsealRequest := UnsealRequest{
+			Key: key,
+		}
+		jsonBlock, err := json.Marshal(&unsealRequest)
+		if err != nil {
+			vc.logger.Error(fmt.Sprintf("failed to build the Vault unseal request (key shares parameter): %s", err.Error()))
+			return 0, err
+		}
+		req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewBuffer(jsonBlock))
+		req.Header.Set("Content-Type", JsonContentType)
+		resp, err := vc.client.Do(req)
+		if err != nil {
+			vc.logger.Error(fmt.Sprintf("failed to send the Vault init request: %s", err.Error()))
+			return 0, err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			vc.logger.Error(fmt.Sprintf("vault unseal request failed with status code: %s", resp.Status))
+			return resp.StatusCode, err
+		}
+
+		unsealedBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			vc.logger.Error(fmt.Sprintf("failed to fetch the Vault unseal request response body: %s", err.Error()))
+			return 0, err
+		}
+		unsealResponse := UnsealResponse{}
+		if err = json.Unmarshal(unsealedBody, &unsealResponse); err != nil {
+			vc.logger.Error(fmt.Sprintf("failed to build the JSON structure from the unseal request response body: %s", err.Error()))
+			return 0, err
+		}
+
+		vc.logger.Info(fmt.Sprintf("Vault key share %d/%d successfully applied.", keyCounter, config.VaultSecretShares))
+		if !unsealResponse.Sealed {
+			vc.logger.Info("Vault key share threshold reached. Unsealing complete.")
+			return resp.StatusCode, nil
+		}
+		keyCounter++
+	}
+	return 0, fmt.Errorf("%d", 1)
+}
+
+func (vc *vaultClient) InstallPolicy(
+	token authtokenreader.AuthTokenReader,
+	policyName string,
+	policyDocument string) (statusCode int, err error) {
+
+	path := fmt.Sprintf(CreatePolicyPath, url.PathEscape(policyName))
+	url := &url.URL{
+		Scheme: vc.scheme,
+		Host:   vc.host,
+		Path:   path,
+	}
+
+	request := UpdateAclPolicyRequest{Policy: policyDocument}
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to build the Vault create policy request: %s", err.Error()))
+		return 0, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, url.String(), bytes.NewReader(requestBytes))
+	req.Header.Set(VaultToken, token.AuthToken())
+	req.Header.Set("Content-Type", JsonContentType)
+	resp, err := vc.client.Do(req)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to send Vault create policy request: %s", err.Error()))
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		vc.logger.Error(fmt.Sprintf("vault create policy request failed with status: %s", resp.Status))
+		return resp.StatusCode, err
+	}
+
+	vc.logger.Info(fmt.Sprintf("Created vault policy %s", policyName))
+	return resp.StatusCode, nil
+}
+
+func (vc *vaultClient) CreateToken(token authtokenreader.AuthTokenReader, parameters map[string]interface{}, response interface{}) (statusCode int, err error) {
+	url := &url.URL{
+		Scheme: vc.scheme,
+		Host:   vc.host,
+		Path:   CreateTokenAPI,
+	}
+
+	tokenName, ok := parameters["display_name"].(string)
+	if !ok {
+		tokenName = "UNKNOWN DISPLAY_NAME"
+	}
+	body, err := json.Marshal(parameters)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to build the Vault create token request: %s", err.Error()))
+		return 0, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(body))
+	req.Header.Set(VaultToken, token.AuthToken())
+	req.Header.Set("Content-Type", JsonContentType)
+	resp, err := vc.client.Do(req)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to send Vault create token request: %s", err.Error()))
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		vc.logger.Error(fmt.Sprintf("vault create token request failed with status: %s", resp.Status))
+		return resp.StatusCode, err
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to parse response body: %s", err.Error()))
+		return 0, err
+	}
+
+	vc.logger.Info(fmt.Sprintf("Created vault token %s", tokenName))
+	return resp.StatusCode, nil
+}

--- a/internal/security/vaultclient/vault_test.go
+++ b/internal/security/vaultclient/vault_test.go
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+
+ *******************************************************************************/
+
+package vaultclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/authtokenreader/mocks"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthCheck(t *testing.T) {
+	mockLogger := logger.MockLogger{}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.Method != "GET" {
+			t.Errorf("expected GET request, got %s instead", r.Method)
+		}
+
+		if r.URL.EscapedPath() != fmt.Sprintf("%s", VaultHealthAPI) {
+			t.Errorf("expected request to /%s, got %s instead", VaultHealthAPI, r.URL.EscapedPath())
+		}
+	}))
+	defer ts.Close()
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewVaultClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+	code, _ := vc.HealthCheck()
+
+	if code != http.StatusOK {
+		t.Errorf("incorrect vault health check status.")
+	}
+}
+
+func TestInit(t *testing.T) {
+	mockLogger := logger.MockLogger{}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"keys": [
+			  "test-keys"
+			],
+			"keys_base64": [
+			  "test-keys-base64"
+			],
+			"root_token": "test-root-token"
+		}
+		`))
+		if r.Method != "POST" {
+			t.Errorf("expected POST request, got %s instead", r.Method)
+		}
+
+		if r.URL.EscapedPath() != fmt.Sprintf("%s", VaultInitAPI) {
+			t.Errorf("expected request to /%s, got %s instead", VaultInitAPI, r.URL.EscapedPath())
+		}
+	}))
+	defer ts.Close()
+
+	config := SecretServiceInfo{
+		TokenFolderPath: "testdata",
+		TokenFile:       "test-resp-init.json",
+	}
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewVaultClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+	tokenFile, err := os.OpenFile(filepath.Join(config.TokenFolderPath, config.TokenFile), os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		t.Errorf("failed to open token file %s", err.Error())
+	}
+	defer tokenFile.Close()
+	code, _ := vc.Init(config, tokenFile)
+	if code != http.StatusOK {
+		t.Errorf("incorrect vault init status. The returned code is %d", code)
+	}
+}
+
+func TestUnseal(t *testing.T) {
+	mockLogger := logger.MockLogger{}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"sealed": false, "t": 1, "n": 1, "progress": 100}`))
+		if r.Method != "POST" {
+			t.Errorf("expected POST request, got %s instead", r.Method)
+		}
+
+		if r.URL.EscapedPath() != fmt.Sprintf("%s", VaultUnsealAPI) {
+			t.Errorf("expected request to /%s, got %s instead", VaultUnsealAPI, r.URL.EscapedPath())
+		}
+	}))
+	defer ts.Close()
+
+	config := SecretServiceInfo{
+		TokenFolderPath:   "testdata",
+		TokenFile:         "test-resp-init.json",
+		VaultSecretShares: 1,
+	}
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewVaultClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+	tokenFile, err := fileioperformer.NewDefaultFileIoPerformer().OpenFileReader(filepath.Join(config.TokenFolderPath, config.TokenFile), os.O_RDONLY, 0400)
+	if err != nil {
+		t.Errorf("failed to open token file %s", err.Error())
+	}
+	code, err := vc.Unseal(config, tokenFile)
+	if code != http.StatusOK {
+		t.Errorf("incorrect vault unseal status. The returned code is %d, %s", code, err.Error())
+	}
+}
+
+func TestInstallPolicy(t *testing.T) {
+	// Arrange
+	assert := assert.New(t)
+	mockLogger := logger.MockLogger{}
+	mockAuthTokenReader := &MockAuthTokenReader{}
+	mockAuthTokenReader.On("AuthToken").Return("fake-token")
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("PUT", r.Method)
+		assert.Equal("/v1/sys/policies/acl/policy-name", r.URL.EscapedPath())
+		assert.Equal("fake-token", r.Header.Get("X-Vault-Token"))
+
+		// Make sure the policy doc was base64 encoded in the json response object
+		body := make(map[string]interface{})
+		err := json.NewDecoder(r.Body).Decode(&body)
+		assert.Nil(err)
+		assert.Equal("policydoc", body["policy"].(string))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewVaultClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+
+	// Act
+	policyDoc := "policydoc"
+	code, err := vc.InstallPolicy(mockAuthTokenReader, "policy-name", policyDoc)
+
+	// Assert
+	assert.Nil(err)
+	mockAuthTokenReader.AssertExpectations(t)
+	assert.Equal(http.StatusNoContent, code)
+}
+
+func TestCreateToken(t *testing.T) {
+	// Arrange
+	assert := assert.New(t)
+	mockLogger := logger.MockLogger{}
+	mockAuthTokenReader := &MockAuthTokenReader{}
+	mockAuthTokenReader.On("AuthToken").Return("fake-token")
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("POST", r.Method)
+		assert.Equal(CreateTokenAPI, r.URL.EscapedPath())
+		assert.Equal("fake-token", r.Header.Get("X-Vault-Token"))
+
+		body := make(map[string]interface{})
+		err := json.NewDecoder(r.Body).Decode(&body)
+		assert.Nil(err)
+
+		assert.Equal("sample-value", body["sample_parameter"])
+
+		w.WriteHeader(http.StatusOK)
+
+		response := struct {
+			RequestID string `json:"request_id"`
+		}{
+			RequestID: "f00341c1-fad5-f6e6-13fd-235617f858a1",
+		}
+		err = json.NewEncoder(w).Encode(response)
+		assert.Nil(err)
+
+	}))
+	defer ts.Close()
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewVaultClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+
+	// Act
+	parameters := make(map[string]interface{})
+	parameters["sample_parameter"] = "sample-value"
+	response := make(map[string]interface{})
+	code, err := vc.CreateToken(mockAuthTokenReader, parameters, &response)
+
+	// Assert
+	assert.Nil(err)
+	mockAuthTokenReader.AssertExpectations(t)
+	assert.Equal(http.StatusOK, code)
+	assert.Equal("f00341c1-fad5-f6e6-13fd-235617f858a1", response["request_id"].(string))
+}


### PR DESCRIPTION
Implements an executable that reads a configuration file to
create per-service security tokens for EdgeX services.
Besides the executable, several modules are involved:

 - authtokenreader - a component that reads a Vault token
   out of a JSON file; can be a service token or root token

 - fileioperformer - an abstraction layer for file I/O used
   to facilicitate unit testing

 - fileprovider - contains main business logic

 - tokenconfig - a component to process the config file
   used by fileprovider to create service tokens

 - vaultclient - a standalone component to talk to Vault
   enhanced with methods for creating policies and tokens

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>